### PR TITLE
Sort imports with isort

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - run: pip install isort
+      - run: pip install -r requirements.txt
+      - name: Check import order
+        run: isort --profile black --check .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 
 import sphinx_rtd_theme

--- a/pyhanko/cli.py
+++ b/pyhanko/cli.py
@@ -1,40 +1,43 @@
+import getpass
+import logging
 import sys
 from contextlib import contextmanager
 from datetime import datetime
 from enum import Enum, auto
 
 import click
-import logging
-import getpass
-
 import tzlocal
-from asn1crypto import pem, cms
-
-from pyhanko.pdf_utils.layout import LayoutError
+from asn1crypto import cms, pem
 from pyhanko_certvalidator import ValidationContext
-from pyhanko.config import (
-    init_validation_context_kwargs, parse_cli_config,
-    CLIConfig, LogConfig, StdLogOutput, parse_logging_config,
-    PKCS11SignatureConfig, PKCS12SignatureConfig, PemDerSignatureConfig
-)
-from pyhanko.pdf_utils import misc
-from pyhanko.pdf_utils.config_utils import ConfigurationError
 
-from pyhanko.sign import signers, validation, fields
+from pyhanko import __version__
+from pyhanko.config import (
+    CLIConfig,
+    LogConfig,
+    PemDerSignatureConfig,
+    PKCS11SignatureConfig,
+    PKCS12SignatureConfig,
+    StdLogOutput,
+    init_validation_context_kwargs,
+    parse_cli_config,
+    parse_logging_config,
+)
+from pyhanko.pdf_utils import crypt, misc
+from pyhanko.pdf_utils.config_utils import ConfigurationError
+from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+from pyhanko.pdf_utils.layout import LayoutError
+from pyhanko.pdf_utils.reader import PdfFileReader
+from pyhanko.pdf_utils.writer import copy_into_new_writer
+from pyhanko.sign import fields, signers, validation
 from pyhanko.sign.general import (
-    SigningError, SignatureValidationError, load_certs_from_pemder
+    SignatureValidationError,
+    SigningError,
+    load_certs_from_pemder,
 )
 from pyhanko.sign.signers import DEFAULT_SIGNER_KEY_USAGE
 from pyhanko.sign.timestamps import HTTPTimeStamper
-from pyhanko.pdf_utils.reader import PdfFileReader
-from pyhanko.pdf_utils.writer import copy_into_new_writer
-from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
-from pyhanko.pdf_utils import crypt
-from pyhanko.sign.validation import (
-    RevocationInfoValidationType
-)
-from pyhanko.stamp import QRStampStyle, text_stamp_file, qr_stamp_file
-from pyhanko import __version__
+from pyhanko.sign.validation import RevocationInfoValidationType
+from pyhanko.stamp import QRStampStyle, qr_stamp_file, text_stamp_file
 
 __all__ = ['cli']
 

--- a/pyhanko/config.py
+++ b/pyhanko/config.py
@@ -1,20 +1,17 @@
 import enum
 import logging
-from datetime import timedelta
-from typing import Dict, Optional, Union, List, Iterable
 from dataclasses import dataclass
+from datetime import timedelta
+from typing import Dict, Iterable, List, Optional, Union
 
 import yaml
 from asn1crypto import x509
+from pyhanko_certvalidator import ValidationContext
 
 from pyhanko.pdf_utils import config_utils
-from pyhanko_certvalidator import ValidationContext
-from pyhanko.pdf_utils.config_utils import (
-    check_config_keys, ConfigurationError
-)
+from pyhanko.pdf_utils.config_utils import ConfigurationError, check_config_keys
 from pyhanko.pdf_utils.misc import get_and_apply
-
-from pyhanko.sign import load_certs_from_pemder, SimpleSigner
+from pyhanko.sign import SimpleSigner, load_certs_from_pemder
 from pyhanko.sign.general import KeyUsageConstraints
 from pyhanko.sign.signers import DEFAULT_SIGNING_STAMP_STYLE
 from pyhanko.stamp import QRStampStyle, TextStampStyle

--- a/pyhanko/pdf_utils/_saslprep.py
+++ b/pyhanko/pdf_utils/_saslprep.py
@@ -21,8 +21,8 @@
 __all__ = ['saslprep']
 
 import stringprep
-
 import unicodedata
+
 # RFC4013 section 2.3 prohibited output.
 _PROHIBITED = (
     # A strict reading of RFC 4013 requires table c12 here, but

--- a/pyhanko/pdf_utils/barcodes.py
+++ b/pyhanko/pdf_utils/barcodes.py
@@ -10,8 +10,8 @@ except ImportError as e:  # pragma: nocover
     )
 
 from pyhanko.pdf_utils.content import PdfContent
-from pyhanko.pdf_utils.misc import rd
 from pyhanko.pdf_utils.layout import BoxConstraints
+from pyhanko.pdf_utils.misc import rd
 
 __all__ = ['BarcodeBox', 'PdfStreamBarcodeWriter']
 

--- a/pyhanko/pdf_utils/config_utils.py
+++ b/pyhanko/pdf_utils/config_utils.py
@@ -9,8 +9,9 @@ user-provided configuration (e.g. from a Yaml file).
 
 import dataclasses
 import re
-from typing import Type, Optional, Union
-from asn1crypto.core import ObjectIdentifier, BitString
+from typing import Optional, Type, Union
+
+from asn1crypto.core import BitString, ObjectIdentifier
 
 __all__ = [
     'ConfigurationError', 'ConfigurableMixin', 'check_config_keys',

--- a/pyhanko/pdf_utils/content.py
+++ b/pyhanko/pdf_utils/content.py
@@ -1,13 +1,10 @@
 import binascii
 import uuid
 from enum import Enum
-from .generic import (
-    pdf_name, DictionaryObject, NameObject,
-    PdfObject, StreamObject,
-)
+
+from .generic import DictionaryObject, NameObject, PdfObject, StreamObject, pdf_name
 from .layout import BoxConstraints
 from .reader import PdfFileReader
-
 
 __all__ = [
     'ResourceType', 'ResourceManagementError',

--- a/pyhanko/pdf_utils/crypt.py
+++ b/pyhanko/pdf_utils/crypt.py
@@ -53,23 +53,22 @@ uses of crypt filters:
 As long as you don't require access to encoded object data and/or raw encrypted
 object data, this distiction should be irrelevant to you as an API user.
 """
-import logging
 import abc
-import struct
-import secrets
 import enum
+import logging
+import secrets
+import struct
 from dataclasses import dataclass
-from hashlib import md5, sha256, sha384, sha512, sha1
-from typing import Dict, Type, Optional, Tuple, Union, List, Set, Callable
+from hashlib import md5, sha1, sha256, sha384, sha512
+from typing import Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
-from asn1crypto import x509, cms, algos
-from asn1crypto.keys import PublicKeyAlgorithm, PrivateKeyInfo
+from asn1crypto import algos, cms, x509
+from asn1crypto.keys import PrivateKeyInfo, PublicKeyAlgorithm
 from cryptography.hazmat.primitives import padding, serialization
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey, \
-    RSAPrivateKey
-from cryptography.hazmat.primitives.serialization import pkcs12
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.serialization import pkcs12
 
 from . import generic, misc
 
@@ -2247,8 +2246,8 @@ class SimpleEnvelopeKeyDecrypter(EnvelopeKeyDecrypter):
             )
 
             from ..sign.general import (
+                _translate_pyca_cryptography_cert_to_asn1,
                 _translate_pyca_cryptography_key_to_asn1,
-                _translate_pyca_cryptography_cert_to_asn1
             )
             cert = _translate_pyca_cryptography_cert_to_asn1(cert)
             private_key = _translate_pyca_cryptography_key_to_asn1(private_key)
@@ -2339,6 +2338,7 @@ def read_seed_from_recipient_cms(recipient_cms: cms.ContentInfo,
     try:
         # noinspection PyUnresolvedReferences
         from oscrypto import symmetric
+
         # The spec mandates that we support these, but pyca/cryptography
         # doesn't offer implementations.
         # (DES and 3DES have fortunately gone out of style, but some libraries

--- a/pyhanko/pdf_utils/embed.py
+++ b/pyhanko/pdf_utils/embed.py
@@ -7,11 +7,11 @@ Utility classes for handling embedded files in PDFs.
 import hashlib
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, List
+from typing import List, Optional
 
 from asn1crypto import x509
 
-from . import generic, writer, misc, crypt
+from . import crypt, generic, misc, writer
 from .generic import pdf_name, pdf_string
 
 __all__ = [

--- a/pyhanko/pdf_utils/filters.py
+++ b/pyhanko/pdf_utils/filters.py
@@ -9,12 +9,11 @@ In particular ``/Crypt`` and ``/LZWDecode`` are missing.
 """
 import binascii
 import re
+import struct
+import zlib
+from io import BytesIO
 
 from .misc import PdfReadError, PdfStreamError, Singleton
-from io import BytesIO
-import struct
-
-import zlib
 
 __all__ = [
     'Decoder', 'ASCII85Decode', 'ASCIIHexDecode', 'FlateDecode',

--- a/pyhanko/pdf_utils/font/__init__.py
+++ b/pyhanko/pdf_utils/font/__init__.py
@@ -1,4 +1,4 @@
-from .api import ShapeResult, FontEngine, FontEngineFactory
+from .api import FontEngine, FontEngineFactory, ShapeResult
 from .basic import SimpleFontEngine, SimpleFontEngineFactory
 
 __all__ = [

--- a/pyhanko/pdf_utils/font/api.py
+++ b/pyhanko/pdf_utils/font/api.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 from pyhanko.pdf_utils import generic
 
@@ -8,7 +8,6 @@ __all__ = [
 ]
 
 from pyhanko.pdf_utils.writer import BasePdfFileWriter
-
 
 ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 

--- a/pyhanko/pdf_utils/font/basic.py
+++ b/pyhanko/pdf_utils/font/basic.py
@@ -1,6 +1,7 @@
 from pyhanko.pdf_utils import generic
-from .api import FontEngine, ShapeResult, FontEngineFactory
+
 from ..writer import BasePdfFileWriter
+from .api import FontEngine, FontEngineFactory, ShapeResult
 
 pdf_name = generic.NameObject
 

--- a/pyhanko/pdf_utils/font/opentype.py
+++ b/pyhanko/pdf_utils/font/opentype.py
@@ -4,20 +4,18 @@ This module relies on `fontTools <https://pypi.org/project/fonttools/>`_ for
 OTF parsing and subsetting, and on HarfBuzz (via ``uharfbuzz``) for shaping.
 """
 import logging
+from binascii import hexlify
 from dataclasses import dataclass
 from io import BytesIO
-from binascii import hexlify
 
 from pyhanko.pdf_utils import generic
-from pyhanko.pdf_utils.font.api import (
-    ShapeResult, FontEngine, FontEngineFactory
-)
+from pyhanko.pdf_utils.font.api import FontEngine, FontEngineFactory, ShapeResult
 from pyhanko.pdf_utils.misc import peek
 from pyhanko.pdf_utils.writer import BasePdfFileWriter
 
 try:
     import uharfbuzz as hb
-    from fontTools import ttLib, subset
+    from fontTools import subset, ttLib
 except ImportError as import_err:  # pragma: nocover
     raise ImportError(
         "pyhanko.pdf_utils.font.opentype requires pyHanko to be installed with "

--- a/pyhanko/pdf_utils/generic.py
+++ b/pyhanko/pdf_utils/generic.py
@@ -5,25 +5,28 @@ The internals were imported from PyPDF2, with modifications.
 See :ref:`here <pypdf2-license>` for the original license
 of the PyPDF2 project.
 """
+import binascii
+import codecs
+import decimal
+import logging
 import os
 import re
-import binascii
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
-from typing import Iterator, Tuple, Optional, Union, Callable, Any
-from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator, Optional, Tuple, Union
 
-from .misc import (
-    read_non_whitespace, skip_over_comment, read_until_regex,
-    is_regular_character
-)
-from .misc import (
-    PdfStreamError, PdfReadError, IndirectObjectExpected, PdfWriteError
-)
-import logging
 from . import filters
-import decimal
-import codecs
+from .misc import (
+    IndirectObjectExpected,
+    PdfReadError,
+    PdfStreamError,
+    PdfWriteError,
+    is_regular_character,
+    read_non_whitespace,
+    read_until_regex,
+    skip_over_comment,
+)
 
 __all__ = [
     'Dereferenceable', 'Reference', 'TrailerReference',

--- a/pyhanko/pdf_utils/images.py
+++ b/pyhanko/pdf_utils/images.py
@@ -17,13 +17,12 @@ The image data handling is done by
 """
 
 import uuid
-
 from typing import Union
 
-from .layout import BoxConstraints
-from .generic import pdf_name
-from .content import ResourceType, PdfResources, PdfContent
 from . import generic
+from .content import PdfContent, PdfResources, ResourceType
+from .generic import pdf_name
+from .layout import BoxConstraints
 from .writer import BasePdfFileWriter
 
 try:

--- a/pyhanko/pdf_utils/incremental_writer.py
+++ b/pyhanko/pdf_utils/incremental_writer.py
@@ -3,15 +3,13 @@ Utility for writing incremental updates to existing PDF files.
 """
 
 import os
-from typing import Union, Optional
+from typing import Optional, Union
 
 from . import generic, misc
 from .crypt import EnvelopeKeyDecrypter
-
-from .reader import PdfFileReader, parse_catalog_version
 from .generic import pdf_name
+from .reader import PdfFileReader, parse_catalog_version
 from .writer import BasePdfFileWriter
-
 
 __all__ = ['IncrementalPdfFileWriter']
 

--- a/pyhanko/pdf_utils/misc.py
+++ b/pyhanko/pdf_utils/misc.py
@@ -26,9 +26,7 @@ __all__ = [
 ]
 
 from io import BytesIO
-
-from typing import Callable, TypeVar, Generator, Iterable
-
+from typing import Callable, Generator, Iterable, TypeVar
 
 DEFAULT_CHUNK_SIZE = 4096
 """
@@ -184,7 +182,7 @@ def get_courier():
         A resource dictionary representing the standard Courier font
         (or one of its metric equivalents).
     """
-    from .generic import pdf_name, DictionaryObject
+    from .generic import DictionaryObject, pdf_name
     return DictionaryObject({
         pdf_name('/Type'): pdf_name('/Font'),
         pdf_name('/Subtype'): pdf_name('/Type1'),

--- a/pyhanko/pdf_utils/reader.py
+++ b/pyhanko/pdf_utils/reader.py
@@ -10,23 +10,23 @@ This comes at a cost, and future iterations of this module may offer more
 flexibility in terms of the level of detail with which file size is scrutinised.
 """
 
-import struct
+import logging
 import os
 import re
+import struct
 from collections import defaultdict
 from io import BytesIO
 from itertools import chain
-from typing import Set, List, Optional, Union, Tuple
+from typing import List, Optional, Set, Tuple, Union
 
 from . import generic, misc
-from .misc import PdfReadError
 from .crypt import (
-    SecurityHandler, StandardSecurityHandler,
-    EnvelopeKeyDecrypter, PubKeySecurityHandler,
+    EnvelopeKeyDecrypter,
+    PubKeySecurityHandler,
+    SecurityHandler,
+    StandardSecurityHandler,
 )
-
-import logging
-
+from .misc import PdfReadError
 from .rw_common import PdfHandler
 
 logger = logging.getLogger(__name__)

--- a/pyhanko/pdf_utils/text.py
+++ b/pyhanko/pdf_utils/text.py
@@ -2,13 +2,11 @@
 
 from dataclasses import dataclass, field
 
-from pyhanko.pdf_utils.font import SimpleFontEngineFactory, FontEngineFactory
-from pyhanko.pdf_utils.generic import (
-    pdf_name,
-)
-from pyhanko.pdf_utils.content import ResourceType, PdfResources, PdfContent
 from pyhanko.pdf_utils import layout
 from pyhanko.pdf_utils.config_utils import ConfigurableMixin, ConfigurationError
+from pyhanko.pdf_utils.content import PdfContent, PdfResources, ResourceType
+from pyhanko.pdf_utils.font import FontEngineFactory, SimpleFontEngineFactory
+from pyhanko.pdf_utils.generic import pdf_name
 
 
 @dataclass(frozen=True)

--- a/pyhanko/pdf_utils/writer.py
+++ b/pyhanko/pdf_utils/writer.py
@@ -5,28 +5,25 @@ Contains code from the PyPDF2 project; see :ref:`here <pypdf2-license>`
 for the original license.
 """
 
+import enum
 import os
 import struct
-import enum
 from dataclasses import dataclass
 from io import BytesIO
-from typing import List, Union, Optional, Tuple, Iterable
+from typing import Iterable, List, Optional, Tuple, Union
 
 from asn1crypto import x509
 
-from pyhanko.pdf_utils import generic, content
+from pyhanko import __version__
+from pyhanko.pdf_utils import content, generic
 from pyhanko.pdf_utils.crypt import (
-    SecurityHandler, StandardSecurityHandler,
     PubKeySecurityHandler,
+    SecurityHandler,
+    StandardSecurityHandler,
 )
 from pyhanko.pdf_utils.generic import pdf_name, pdf_string
-from pyhanko.pdf_utils.misc import (
-    peek, PdfReadError, instance_test,
-    PdfWriteError,
-)
+from pyhanko.pdf_utils.misc import PdfReadError, PdfWriteError, instance_test, peek
 from pyhanko.pdf_utils.rw_common import PdfHandler
-from pyhanko import __version__
-
 
 __all__ = [
     'ObjectStream', 'BasePdfFileWriter',

--- a/pyhanko/sign/ades/api.py
+++ b/pyhanko/sign/ades/api.py
@@ -1,14 +1,15 @@
 import enum
 from dataclasses import dataclass
-
 from typing import Optional
 
-from .cades_asn1 import (
-    CommitmentTypeIndication, SignaturePolicyIdentifier,
-    CommitmentTypeIdentifier
-)
 from pyhanko.sign.general import simple_cms_attribute
 from pyhanko.sign.timestamps import TimeStamper
+
+from .cades_asn1 import (
+    CommitmentTypeIdentifier,
+    CommitmentTypeIndication,
+    SignaturePolicyIdentifier,
+)
 
 __all__ = ['GenericCommitment', 'CAdESSignedAttrSpec']
 

--- a/pyhanko/sign/ades/asn1_util.py
+++ b/pyhanko/sign/ades/asn1_util.py
@@ -1,6 +1,6 @@
 from typing import Type
 
-from asn1crypto import core, cms
+from asn1crypto import cms, core
 
 __all__ = ['as_set_of', 'register_cms_attribute']
 

--- a/pyhanko/sign/ades/cades_asn1.py
+++ b/pyhanko/sign/ades/cades_asn1.py
@@ -1,4 +1,5 @@
-from asn1crypto import core, cms, algos
+from asn1crypto import algos, cms, core
+
 from .asn1_util import register_cms_attribute
 
 """

--- a/pyhanko/sign/beid.py
+++ b/pyhanko/sign/beid.py
@@ -6,8 +6,9 @@ This module defines a very thin convenience wrapper around
 read the appropriate certificates on the device.
 """
 
-from . import pkcs11 as sign_pkcs11
 from pkcs11 import Session
+
+from . import pkcs11 as sign_pkcs11
 
 __all__ = ['open_beid_session', 'BEIDSigner']
 

--- a/pyhanko/sign/diff_analysis.py
+++ b/pyhanko/sign/diff_analysis.py
@@ -53,24 +53,30 @@ putting together custom diff rules.
 
 """
 
-import re
 import logging
+import re
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import unique
 from io import BytesIO
 from typing import (
-    Iterable, Optional, Set, Tuple, Generator, TypeVar, Dict,
-    List, Callable, Union, Iterator
+    Callable,
+    Dict,
+    Generator,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
 )
 
-from pyhanko.pdf_utils.generic import Reference, PdfObject
-from pyhanko.pdf_utils.misc import OrderedEnum
-from pyhanko.pdf_utils.reader import (
-    HistoricalResolver, PdfFileReader,
-    RawPdfPath,
-)
 from pyhanko.pdf_utils import generic, misc
+from pyhanko.pdf_utils.generic import PdfObject, Reference
+from pyhanko.pdf_utils.misc import OrderedEnum
+from pyhanko.pdf_utils.reader import HistoricalResolver, PdfFileReader, RawPdfPath
 from pyhanko.sign.fields import FieldMDPSpec, MDPPerm
 
 __all__ = [
@@ -1361,8 +1367,8 @@ class MetadataUpdateRule(WhitelistRule):
                 "/Metadata should be a reference to a stream object"
             )
 
-        from xml.sax.handler import ContentHandler
         from xml.sax import make_parser
+        from xml.sax.handler import ContentHandler
 
         parser = make_parser()
         parser.setContentHandler(ContentHandler())

--- a/pyhanko/sign/fields.py
+++ b/pyhanko/sign/fields.py
@@ -4,25 +4,25 @@ Utilities to deal with signature form fields and their properties in PDF files.
 
 import logging
 from dataclasses import dataclass
-from enum import Flag, Enum, unique
-from typing import List, Optional, Union, Set
+from enum import Enum, Flag, unique
+from typing import List, Optional, Set, Union
 
 from asn1crypto import x509
 from asn1crypto.x509 import KeyUsage
-
-from pyhanko.pdf_utils.content import RawContent
-from pyhanko.pdf_utils.layout import BoxConstraints
 from pyhanko_certvalidator import InvalidCertificateError
 from pyhanko_certvalidator.path import ValidationPath
 
 from pyhanko.pdf_utils import generic
+from pyhanko.pdf_utils.content import RawContent
 from pyhanko.pdf_utils.generic import pdf_name, pdf_string
+from pyhanko.pdf_utils.layout import BoxConstraints
 from pyhanko.pdf_utils.misc import OrderedEnum, PdfWriteError, get_and_apply
 from pyhanko.pdf_utils.rw_common import PdfHandler
 from pyhanko.pdf_utils.writer import BasePdfFileWriter
 from pyhanko.sign.general import (
-    UnacceptableSignerError, SigningError,
     KeyUsageConstraints,
+    SigningError,
+    UnacceptableSignerError,
 )
 
 __all__ = [

--- a/pyhanko/sign/general.py
+++ b/pyhanko/sign/general.py
@@ -6,37 +6,35 @@ CMS is defined in :rfc:`5652`. To parse CMS messages, pyHanko relies heavily on
 `asn1crypto <https://github.com/wbond/asn1crypto>`_.
 """
 
+import hashlib
 import logging
 from dataclasses import dataclass
-from typing import ClassVar, Set, Optional, Tuple, Union
+from typing import ClassVar, Optional, Set, Tuple, Union
 
-import hashlib
-
-from asn1crypto import x509, cms, tsp, algos, pem, keys
+from asn1crypto import algos, cms, keys, pem, tsp, x509
 
 # noinspection PyProtectedMember
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric.ec import (
-    EllipticCurvePublicKey, ECDSA
-)
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.ec import ECDSA, EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
-
-from pyhanko.pdf_utils.config_utils import ConfigurableMixin, \
-    process_bit_string_flags, process_oids
-from pyhanko_certvalidator.path import ValidationPath
-
 from pyhanko_certvalidator import CertificateValidator
-from pyhanko_certvalidator.registry import (
-    CertificateStore, SimpleCertificateStore
-)
 from pyhanko_certvalidator.errors import (
-    RevokedError, PathValidationError, InvalidCertificateError,
-    PathBuildingError
+    InvalidCertificateError,
+    PathBuildingError,
+    PathValidationError,
+    RevokedError,
 )
-from cryptography.hazmat.primitives import serialization, hashes
-from cryptography.hazmat.primitives.asymmetric import padding
+from pyhanko_certvalidator.path import ValidationPath
+from pyhanko_certvalidator.registry import CertificateStore, SimpleCertificateStore
 
+from pyhanko.pdf_utils.config_utils import (
+    ConfigurableMixin,
+    process_bit_string_flags,
+    process_oids,
+)
 
 __all__ = [
     'SignatureStatus', 'simple_cms_attribute',

--- a/pyhanko/sign/pkcs11.py
+++ b/pyhanko/sign/pkcs11.py
@@ -5,23 +5,18 @@ seamlessly plugged into a :class:`~.signers.PdfSigner`.
 """
 import getpass
 import logging
-
-from asn1crypto.algos import RSASSAPSSParams
-
-from pyhanko.config import PKCS11SignatureConfig
 from typing import Set
 
 from asn1crypto import x509
+from asn1crypto.algos import RSASSAPSSParams
 
-from pyhanko.sign.general import (
-    CertificateStore, SimpleCertificateStore, SigningError
-)
+from pyhanko.config import PKCS11SignatureConfig
+from pyhanko.sign.general import CertificateStore, SigningError, SimpleCertificateStore
 from pyhanko.sign.signers import Signer
 
 try:
-    from pkcs11 import (
-        Session, ObjectClass, Attribute, lib as pkcs11_lib, PKCS11Error
-    )
+    from pkcs11 import Attribute, ObjectClass, PKCS11Error, Session
+    from pkcs11 import lib as pkcs11_lib
 except ImportError as e:  # pragma: nocover
     raise ImportError(
         "pyhanko.sign.pkcs11 requires pyHanko to be installed with "
@@ -201,7 +196,7 @@ class PKCS11Signer(Signer):
             return b'0' * 512
 
         self._load_objects()
-        from pkcs11 import Mechanism, SignMixin, MGF
+        from pkcs11 import MGF, Mechanism, SignMixin
 
         kh: SignMixin = self._key_handle
         kwargs = {}

--- a/pyhanko/sign/signers/__init__.py
+++ b/pyhanko/sign/signers/__init__.py
@@ -4,21 +4,24 @@ It contains modules for creating ``SignedData`` CMS objects, embedding them
 in PDF files, and for handling PDF-specific document signing needs.
 """
 
-from .pdf_cms import Signer, SimpleSigner, ExternalSigner
-from .pdf_byterange import (
-    PdfByteRangeDigest, PdfSignedData, SignatureObject, DocumentTimestamp,
-)
-from .pdf_signer import PdfSignatureMetadata, PdfTimeStamper, PdfSigner
-from .functions import sign_pdf, embed_payload_with_cms
-
 # reexport this for backwards compatibility
 from pyhanko.sign.general import load_certs_from_pemder
 
 from .constants import (
-    DEFAULT_MD, DEFAULT_SIGNING_STAMP_STYLE, DEFAULT_SIG_SUBFILTER,
-    DEFAULT_SIGNER_KEY_USAGE
+    DEFAULT_MD,
+    DEFAULT_SIG_SUBFILTER,
+    DEFAULT_SIGNER_KEY_USAGE,
+    DEFAULT_SIGNING_STAMP_STYLE,
 )
-
+from .functions import embed_payload_with_cms, sign_pdf
+from .pdf_byterange import (
+    DocumentTimestamp,
+    PdfByteRangeDigest,
+    PdfSignedData,
+    SignatureObject,
+)
+from .pdf_cms import ExternalSigner, Signer, SimpleSigner
+from .pdf_signer import PdfSignatureMetadata, PdfSigner, PdfTimeStamper
 
 __all__ = [
     'PdfSignatureMetadata', 'Signer', 'SimpleSigner', 'ExternalSigner',

--- a/pyhanko/sign/signers/cms_embedder.py
+++ b/pyhanko/sign/signers/cms_embedder.py
@@ -5,17 +5,20 @@ protocol for embedding CMS payloads into PDF signature objects.
 
 from dataclasses import dataclass
 from datetime import datetime
+from typing import IO, Optional
 
-from pyhanko.pdf_utils.writer import BasePdfFileWriter
-from typing import Optional, IO
-from pyhanko.sign.fields import (
-    MDPPerm, SigFieldSpec, enumerate_sig_fields,
-    prepare_sig_field, ensure_sig_flags,
-    FieldMDPSpec,
-)
 from pyhanko.pdf_utils import generic, misc
 from pyhanko.pdf_utils.generic import pdf_name
 from pyhanko.pdf_utils.layout import BoxConstraints
+from pyhanko.pdf_utils.writer import BasePdfFileWriter
+from pyhanko.sign.fields import (
+    FieldMDPSpec,
+    MDPPerm,
+    SigFieldSpec,
+    ensure_sig_flags,
+    enumerate_sig_fields,
+    prepare_sig_field,
+)
 from pyhanko.sign.general import SigningError
 from pyhanko.stamp import BaseStampStyle, TextStampStyle
 

--- a/pyhanko/sign/signers/constants.py
+++ b/pyhanko/sign/signers/constants.py
@@ -3,10 +3,9 @@ This module defines constants & defaults used by pyHanko when creating digital
 signatures.
 """
 from pyhanko.pdf_utils import generic
-from pyhanko.sign.fields import SigSeedSubFilter
-from pyhanko.stamp import TextStampStyle, STAMP_ART_CONTENT
 from pyhanko.pdf_utils.writer import DeveloperExtension, DevExtensionMultivalued
-
+from pyhanko.sign.fields import SigSeedSubFilter
+from pyhanko.stamp import STAMP_ART_CONTENT, TextStampStyle
 
 __all__ = [
     'DEFAULT_MD', 'DEFAULT_SIG_SUBFILTER', 'DEFAULT_SIGNER_KEY_USAGE',

--- a/pyhanko/sign/signers/functions.py
+++ b/pyhanko/sign/signers/functions.py
@@ -2,10 +2,10 @@
 This module defines pyHanko's high-level API entry points.
 """
 
-import tzlocal
 from datetime import datetime
 from typing import Optional
 
+import tzlocal
 from asn1crypto import cms
 
 from pyhanko.pdf_utils import embed
@@ -16,7 +16,6 @@ from pyhanko.sign.timestamps import TimeStamper
 
 from .pdf_cms import Signer
 from .pdf_signer import PdfSignatureMetadata, PdfSigner
-
 
 __all__ = ['sign_pdf', 'embed_payload_with_cms']
 

--- a/pyhanko/sign/signers/pdf_byterange.py
+++ b/pyhanko/sign/signers/pdf_byterange.py
@@ -3,21 +3,23 @@ This module contains the low-level building blocks for dealing with bookkeeping
 around ``/ByteRange`` digests in PDF files.
 """
 
-from dataclasses import dataclass
-from io import BytesIO
 import binascii
-from cryptography.hazmat.primitives import hashes
+from dataclasses import dataclass
 from datetime import datetime
+from io import BytesIO
+from typing import IO, Optional, Union
+
 from asn1crypto import cms
-from typing import Optional, Union, IO
-from pyhanko.pdf_utils import generic
-from pyhanko.pdf_utils import misc
-from pyhanko.pdf_utils.generic import pdf_name, pdf_date, pdf_string
-from pyhanko.pdf_utils.writer import BasePdfFileWriter
+from cryptography.hazmat.primitives import hashes
+
+from pyhanko.pdf_utils import generic, misc
+from pyhanko.pdf_utils.generic import pdf_date, pdf_name, pdf_string
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+from pyhanko.pdf_utils.writer import BasePdfFileWriter
 from pyhanko.sign.general import SigningError, get_pyca_cryptography_hash
-from . import constants
+
 from ..fields import SigSeedSubFilter
+from . import constants
 
 __all__ = [
     # Serialisable object used to track placeholder locations,

--- a/pyhanko/sign/signers/pdf_cms.py
+++ b/pyhanko/sign/signers/pdf_cms.py
@@ -5,27 +5,36 @@ signatures.
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, Union, IO
 from datetime import datetime
-from cryptography.hazmat.primitives import serialization, hashes
-from cryptography.hazmat.primitives.asymmetric.ec import \
-    EllipticCurvePrivateKey, ECDSA
+from typing import IO, Optional, Union
+
+from asn1crypto import algos, cms, core, keys
+from asn1crypto import pdf as asn1_pdf
+from asn1crypto import x509
+from asn1crypto.algos import SignedDigestAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ec import ECDSA, EllipticCurvePrivateKey
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.serialization import pkcs12
-from asn1crypto import x509, cms, core, keys, algos, pdf as asn1_pdf
-from asn1crypto.algos import SignedDigestAlgorithm
-from pyhanko.sign.general import (
-    CertificateStore, SimpleCertificateStore,
-    SigningError, optimal_pss_params, simple_cms_attribute,
-    get_pyca_cryptography_hash, as_signing_certificate_v2,
-    load_private_key_from_pemder, load_cert_from_pemder,
-    load_certs_from_pemder, _process_pss_params,
-    _translate_pyca_cryptography_cert_to_asn1,
-    _translate_pyca_cryptography_key_to_asn1
-)
+
 from pyhanko.pdf_utils import misc
 from pyhanko.sign.ades.api import CAdESSignedAttrSpec
+from pyhanko.sign.general import (
+    CertificateStore,
+    SigningError,
+    SimpleCertificateStore,
+    _process_pss_params,
+    _translate_pyca_cryptography_cert_to_asn1,
+    _translate_pyca_cryptography_key_to_asn1,
+    as_signing_certificate_v2,
+    get_pyca_cryptography_hash,
+    load_cert_from_pemder,
+    load_certs_from_pemder,
+    load_private_key_from_pemder,
+    optimal_pss_params,
+    simple_cms_attribute,
+)
 
 __all__ = [
     'Signer', 'SimpleSigner', 'ExternalSigner',

--- a/pyhanko/sign/timestamps.py
+++ b/pyhanko/sign/timestamps.py
@@ -7,24 +7,26 @@ The tools in this module allow pyHanko to obtain such tokens from
 authorities.
 """
 
-import struct
 import os
+import struct
 from dataclasses import dataclass
 from datetime import datetime
 
 import requests
 import tzlocal
-from asn1crypto import tsp, algos, cms, x509, keys, core
-from cryptography.hazmat.primitives import serialization, hashes
+from asn1crypto import algos, cms, core, keys, tsp, x509
+from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
-
 from pyhanko_certvalidator import CertificateValidator
 
 from . import general
 from .general import (
-    SignatureStatus, simple_cms_attribute, CertificateStore,
-    SimpleCertificateStore, get_pyca_cryptography_hash,
+    CertificateStore,
+    SignatureStatus,
+    SimpleCertificateStore,
+    get_pyca_cryptography_hash,
+    simple_cms_attribute,
 )
 
 __all__ = [

--- a/pyhanko/sign/validation.py
+++ b/pyhanko/sign/validation.py
@@ -1,46 +1,59 @@
 import hashlib
-import os
 import logging
+import os
 from collections import namedtuple
-from dataclasses import dataclass, field as data_field
+from dataclasses import dataclass
+from dataclasses import field as data_field
 from datetime import datetime
 from enum import Enum, unique
-from typing import TypeVar, Type, Optional, Union, Iterator, IO
+from typing import IO, Iterator, Optional, Type, TypeVar, Union
 
-from asn1crypto import (
-    cms, tsp, ocsp as asn1_ocsp, pdf as asn1_pdf, crl as asn1_crl, x509, keys,
-    core
-)
+from asn1crypto import cms, core
+from asn1crypto import crl as asn1_crl
+from asn1crypto import keys
+from asn1crypto import ocsp as asn1_ocsp
+from asn1crypto import pdf as asn1_pdf
+from asn1crypto import tsp, x509
 from asn1crypto.x509 import Certificate
 from cryptography.hazmat.primitives import hashes
-
-from pyhanko_certvalidator import ValidationContext, CertificateValidator
+from pyhanko_certvalidator import CertificateValidator, ValidationContext
 from pyhanko_certvalidator.path import ValidationPath
 
 from pyhanko.pdf_utils import generic, misc
 from pyhanko.pdf_utils.generic import pdf_name
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
-from pyhanko.pdf_utils.misc import OrderedEnum, get_and_apply, \
-    DEFAULT_CHUNK_SIZE
-from pyhanko.pdf_utils.reader import (
-    PdfFileReader, XRefCache, process_data_at_eof,
-)
+from pyhanko.pdf_utils.misc import DEFAULT_CHUNK_SIZE, OrderedEnum, get_and_apply
+from pyhanko.pdf_utils.reader import PdfFileReader, XRefCache, process_data_at_eof
 from pyhanko.pdf_utils.rw_common import PdfHandler
+
 from .diff_analysis import (
-    SuspiciousModification, ModificationLevel, DEFAULT_DIFF_POLICY, DiffPolicy,
+    DEFAULT_DIFF_POLICY,
+    DiffPolicy,
     DiffResult,
+    ModificationLevel,
+    SuspiciousModification,
 )
 from .fields import (
-    MDPPerm, FieldMDPSpec, SeedLockDocument, SigSeedValueSpec,
-    SigSeedValFlags, SigSeedSubFilter
+    FieldMDPSpec,
+    MDPPerm,
+    SeedLockDocument,
+    SigSeedSubFilter,
+    SigSeedValFlags,
+    SigSeedValueSpec,
 )
 from .general import (
-    SignatureStatus, find_unique_cms_attribute,
-    UnacceptableSignerError, KeyUsageConstraints,
+    DEFAULT_WEAK_HASH_ALGORITHMS,
+    KeyUsageConstraints,
+    MultivaluedAttributeError,
+    NonexistentAttributeError,
+    SignatureStatus,
     SignatureValidationError,
-    validate_sig_integrity, DEFAULT_WEAK_HASH_ALGORITHMS,
-    get_pyca_cryptography_hash, extract_message_digest, match_issuer_serial,
-    MultivaluedAttributeError, NonexistentAttributeError
+    UnacceptableSignerError,
+    extract_message_digest,
+    find_unique_cms_attribute,
+    get_pyca_cryptography_hash,
+    match_issuer_serial,
+    validate_sig_integrity,
 )
 from .timestamps import TimestampSignatureStatus
 

--- a/pyhanko/stamp.py
+++ b/pyhanko/stamp.py
@@ -10,28 +10,21 @@ signature appearances.
 import enum
 import uuid
 from binascii import hexlify
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional
 
 import qrcode
 import tzlocal
 
+from pyhanko.pdf_utils import content, generic, layout
+from pyhanko.pdf_utils.config_utils import ConfigurableMixin, ConfigurationError
+from pyhanko.pdf_utils.generic import pdf_name, pdf_string
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
 from pyhanko.pdf_utils.misc import rd
-from pyhanko.pdf_utils.text import TextBoxStyle, TextBox, DEFAULT_BOX_LAYOUT
-from pyhanko.pdf_utils.writer import (
-    init_xobject_dictionary, BasePdfFileWriter
-)
-from dataclasses import dataclass
-from datetime import datetime
-
-from pyhanko.pdf_utils import generic, layout
-from pyhanko.pdf_utils.generic import (
-    pdf_name, pdf_string,
-)
-from pyhanko.pdf_utils import content
-from pyhanko.pdf_utils.config_utils import ConfigurableMixin, ConfigurationError
 from pyhanko.pdf_utils.qr import PdfStreamQRImage
-
+from pyhanko.pdf_utils.text import DEFAULT_BOX_LAYOUT, TextBox, TextBoxStyle
+from pyhanko.pdf_utils.writer import BasePdfFileWriter, init_xobject_dictionary
 
 __all__ = [
     "AnnotAppearances",
@@ -102,8 +95,9 @@ def _get_background_content(bg_spec) -> content.PdfContent:
         # import first page of PDF as background
         return content.ImportedPdfPage(bg_spec)
     else:
-        from pyhanko.pdf_utils.images import PdfImage
         from PIL import Image
+
+        from pyhanko.pdf_utils.images import PdfImage
         img = Image.open(bg_spec)
         # Setting the writer can be delayed
         return PdfImage(img, writer=None)

--- a/pyhanko_tests/layout_test_utils.py
+++ b/pyhanko_tests/layout_test_utils.py
@@ -1,10 +1,9 @@
 import logging
 import os
+import subprocess
 import tempfile
 
 import pytest
-import subprocess
-
 
 __all__ = ['with_layout_comparison', 'compare_output']
 

--- a/pyhanko_tests/samples.py
+++ b/pyhanko_tests/samples.py
@@ -1,5 +1,5 @@
 import yaml
-from certomancer.registry import CertomancerConfig, ArchLabel
+from certomancer.registry import ArchLabel, CertomancerConfig
 
 from pyhanko.pdf_utils.crypt import SimpleEnvelopeKeyDecrypter
 
@@ -45,7 +45,7 @@ FILE_WITH_EMBEDDED_FONT = read_all(PDF_DATA_DIR + '/fontembed.pdf')
 def simple_page(pdf_out, ascii_text, compress=False, extra_stream=False):
     # based on the minimal pdf file of
     # https://brendanzagaeski.appspot.com/0004.html
-    from pyhanko.pdf_utils import writer, generic
+    from pyhanko.pdf_utils import generic, writer
     from pyhanko.pdf_utils.generic import pdf_name
     from pyhanko.pdf_utils.misc import get_courier
 

--- a/pyhanko_tests/test_barcode.py
+++ b/pyhanko_tests/test_barcode.py
@@ -2,15 +2,13 @@ from io import BytesIO
 
 from freezegun import freeze_time
 
+from pyhanko import stamp
+from pyhanko.pdf_utils import barcodes, generic
 from pyhanko.pdf_utils.generic import pdf_name
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
 from pyhanko.pdf_utils.layout import BoxConstraints
-from pyhanko.pdf_utils import barcodes, generic
-from pyhanko import stamp
-from pyhanko_tests.layout_test_utils import with_layout_comparison, \
-    compare_output
+from pyhanko_tests.layout_test_utils import compare_output, with_layout_comparison
 from pyhanko_tests.samples import MINIMAL
-
 
 EXPECTED_OUTPUT_DIR = 'pyhanko_tests/data/pdf/layout-tests'
 

--- a/pyhanko_tests/test_config.py
+++ b/pyhanko_tests/test_config.py
@@ -1,20 +1,24 @@
 import hashlib
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional, Iterable, Union
+from typing import Iterable, Optional, Union
 
 import pytest
 import yaml
 
 from pyhanko import config, stamp
-from pyhanko.config import StdLogOutput, DEFAULT_ROOT_LOGGER_LEVEL, \
-    DEFAULT_TIME_TOLERANCE, init_validation_context_kwargs
+from pyhanko.config import (
+    DEFAULT_ROOT_LOGGER_LEVEL,
+    DEFAULT_TIME_TOLERANCE,
+    StdLogOutput,
+    init_validation_context_kwargs,
+)
 from pyhanko.pdf_utils import layout
-from pyhanko.pdf_utils.config_utils import ConfigurationError, ConfigurableMixin
+from pyhanko.pdf_utils.config_utils import ConfigurableMixin, ConfigurationError
 from pyhanko.pdf_utils.content import ImportedPdfPage
 from pyhanko.pdf_utils.images import PdfImage
 from pyhanko.stamp import QRStampStyle, TextStampStyle
-from pyhanko_tests.samples import TESTING_CA_DIR, CRYPTO_DATA_DIR
+from pyhanko_tests.samples import CRYPTO_DATA_DIR, TESTING_CA_DIR
 
 
 @pytest.mark.parametrize('trust_replace', [True, False])
@@ -45,9 +49,9 @@ def test_read_vc_kwargs(trust_replace):
 
 
 def test_read_qr_config():
-    from pyhanko_tests.test_text import NOTO_SERIF_JP
     from pyhanko.pdf_utils.font import SimpleFontEngineFactory
     from pyhanko.pdf_utils.font.opentype import GlyphAccumulatorFactory
+    from pyhanko_tests.test_text import NOTO_SERIF_JP
 
     config_string = f"""
     stamp-styles:

--- a/pyhanko_tests/test_diff_analysis.py
+++ b/pyhanko_tests/test_diff_analysis.py
@@ -7,29 +7,37 @@ import pytz
 from freezegun.api import freeze_time
 
 from pyhanko.pdf_utils import generic
-from pyhanko.pdf_utils.generic import pdf_name
 from pyhanko.pdf_utils.content import RawContent
+from pyhanko.pdf_utils.generic import pdf_name
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
-from pyhanko.pdf_utils.writer import copy_into_new_writer
 from pyhanko.pdf_utils.layout import BoxConstraints
-from pyhanko.pdf_utils.reader import (
-    PdfFileReader, HistoricalResolver,
-    RawPdfPath,
-)
-from pyhanko.sign import signers, fields
+from pyhanko.pdf_utils.reader import HistoricalResolver, PdfFileReader, RawPdfPath
+from pyhanko.pdf_utils.writer import copy_into_new_writer
+from pyhanko.sign import fields, signers
 from pyhanko.sign.diff_analysis import (
-    ModificationLevel, is_annot_visible, is_field_visible,
-    NO_CHANGES_DIFF_POLICY, SuspiciousModification, QualifiedWhitelistRule,
-    ReferenceUpdate, StandardDiffPolicy, DEFAULT_DIFF_POLICY, XrefStreamRule,
+    DEFAULT_DIFF_POLICY,
+    NO_CHANGES_DIFF_POLICY,
+    ModificationLevel,
+    QualifiedWhitelistRule,
+    ReferenceUpdate,
+    StandardDiffPolicy,
+    SuspiciousModification,
+    XrefStreamRule,
+    is_annot_visible,
+    is_field_visible,
 )
 from pyhanko.sign.general import SigningError
-from pyhanko.sign.validation import validate_pdf_signature, \
-    SignatureCoverageLevel
+from pyhanko.sign.validation import SignatureCoverageLevel, validate_pdf_signature
 from pyhanko_tests.samples import *
 from pyhanko_tests.test_signing import (
-    FROM_CA, val_trusted, val_untrusted,
-    val_trusted_but_modified, live_testing_vc, PADES, DUMMY_TS,
+    DUMMY_TS,
+    FROM_CA,
+    PADES,
     SIMPLE_V_CONTEXT,
+    live_testing_vc,
+    val_trusted,
+    val_trusted_but_modified,
+    val_untrusted,
 )
 
 

--- a/pyhanko_tests/test_embed.py
+++ b/pyhanko_tests/test_embed.py
@@ -6,10 +6,10 @@ import pytest
 import tzlocal
 from freezegun import freeze_time
 
+from pyhanko.pdf_utils import crypt, embed, generic, misc, writer
 from pyhanko.pdf_utils.crypt import AuthStatus
-from pyhanko.pdf_utils.reader import PdfFileReader
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
-from pyhanko.pdf_utils import writer, embed, generic, misc, crypt
+from pyhanko.pdf_utils.reader import PdfFileReader
 from pyhanko_tests.samples import *
 
 

--- a/pyhanko_tests/test_images.py
+++ b/pyhanko_tests/test_images.py
@@ -1,13 +1,14 @@
+import os
 from io import BytesIO
 
 import pytest
-import os
 from PIL import Image
-from .samples import *
-from pyhanko.pdf_utils import images
-from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
-from pyhanko.pdf_utils import generic
+
+from pyhanko.pdf_utils import generic, images
 from pyhanko.pdf_utils.generic import pdf_name
+from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+
+from .samples import *
 
 IMG_DIR = 'pyhanko_tests/data/img'
 

--- a/pyhanko_tests/test_key_usage_constraints.py
+++ b/pyhanko_tests/test_key_usage_constraints.py
@@ -1,8 +1,8 @@
 import pytest
-from asn1crypto.x509 import KeyUsage, ExtKeyUsageSyntax
+from asn1crypto.x509 import ExtKeyUsageSyntax, KeyUsage
+from pyhanko_certvalidator import InvalidCertificateError
 
 from pyhanko.sign.general import KeyUsageConstraints
-from pyhanko_certvalidator import InvalidCertificateError
 
 
 @pytest.mark.parametrize('cfg, cert_ku', [

--- a/pyhanko_tests/test_pkcs11.py
+++ b/pyhanko_tests/test_pkcs11.py
@@ -4,12 +4,11 @@ Tests for PKCS#11 functionality.
 NOTE: these are not run in CI, due to lack of testing setup.
 """
 
+import logging
 import os
 from io import BytesIO
 
 import pytest
-import logging
-
 from certomancer.registry import CertLabel
 from freezegun import freeze_time
 from pkcs11 import PKCS11Error
@@ -17,11 +16,11 @@ from pkcs11 import PKCS11Error
 from pyhanko.config import PKCS11SignatureConfig
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
 from pyhanko.pdf_utils.reader import PdfFileReader
-from pyhanko.sign import signers, pkcs11
+from pyhanko.sign import pkcs11, signers
 from pyhanko.sign.general import SigningError
 from pyhanko.sign.pkcs11 import PKCS11SigningContext
 from pyhanko_tests.samples import MINIMAL, TESTING_CA
-from pyhanko_tests.test_signing import val_trusted, SIMPLE_ECC_V_CONTEXT
+from pyhanko_tests.test_signing import SIMPLE_ECC_V_CONTEXT, val_trusted
 
 logger = logging.getLogger(__name__)
 

--- a/pyhanko_tests/test_seed_values.py
+++ b/pyhanko_tests/test_seed_values.py
@@ -1,8 +1,8 @@
 from io import BytesIO
 
 import pytest
-from pyhanko_certvalidator import CertificateValidator
 from freezegun.api import freeze_time
+from pyhanko_certvalidator import CertificateValidator
 
 from pyhanko.pdf_utils import generic
 from pyhanko.pdf_utils.generic import pdf_name
@@ -11,15 +11,24 @@ from pyhanko.pdf_utils.reader import PdfFileReader
 from pyhanko.sign import fields, signers
 from pyhanko.sign.general import SigningError, UnacceptableSignerError
 from pyhanko.sign.validation import (
-    validate_pdf_signature,
-    EmbeddedPdfSignature, validate_pdf_ltv_signature,
+    EmbeddedPdfSignature,
     RevocationInfoValidationType,
+    validate_pdf_ltv_signature,
+    validate_pdf_signature,
 )
 from pyhanko_tests.samples import MINIMAL
 from pyhanko_tests.test_signing import (
-    FROM_CA, INTERM_CERT, DUMMY_TS,
-    SELF_SIGN, live_testing_vc, ROOT_CERT, dummy_ocsp_vc, PADES, TRUST_ROOTS,
-    DUMMY_HTTP_TS, ts_response_callback,
+    DUMMY_HTTP_TS,
+    DUMMY_TS,
+    FROM_CA,
+    INTERM_CERT,
+    PADES,
+    ROOT_CERT,
+    SELF_SIGN,
+    TRUST_ROOTS,
+    dummy_ocsp_vc,
+    live_testing_vc,
+    ts_response_callback,
 )
 
 

--- a/pyhanko_tests/test_stamp.py
+++ b/pyhanko_tests/test_stamp.py
@@ -3,20 +3,25 @@ from pathlib import Path
 
 import pytest
 
-from pyhanko.pdf_utils import layout, writer, generic
-from pyhanko.pdf_utils.content import RawContent, ImportedPdfPage
+from pyhanko.pdf_utils import generic, layout, writer
+from pyhanko.pdf_utils.content import ImportedPdfPage, RawContent
 from pyhanko.pdf_utils.font.opentype import GlyphAccumulatorFactory
 from pyhanko.pdf_utils.images import PdfImage
 from pyhanko.pdf_utils.text import TextBoxStyle
-from .samples import *
-
-from .layout_test_utils import with_layout_comparison, compare_output
-
 from pyhanko.stamp import (
-    text_stamp_file, qr_stamp_file, TextStampStyle,
-    QRStampStyle, TextStamp, QRPosition, STAMP_ART_CONTENT, QRStamp,
-    StaticStampStyle
+    STAMP_ART_CONTENT,
+    QRPosition,
+    QRStamp,
+    QRStampStyle,
+    StaticStampStyle,
+    TextStamp,
+    TextStampStyle,
+    qr_stamp_file,
+    text_stamp_file,
 )
+
+from .layout_test_utils import compare_output, with_layout_comparison
+from .samples import *
 
 FONT_DIR = 'pyhanko_tests/data/fonts'
 NOTO_SERIF_JP = f'{FONT_DIR}/NotoSerifJP-Regular.otf'

--- a/pyhanko_tests/test_text.py
+++ b/pyhanko_tests/test_text.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 import pytest
 
-from pyhanko.pdf_utils import text, generic
+from pyhanko.pdf_utils import generic, text
 from pyhanko.pdf_utils.font.opentype import GlyphAccumulator
 from pyhanko.pdf_utils.generic import pdf_name
 from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter

--- a/pyhanko_tests/test_utils.py
+++ b/pyhanko_tests/test_utils.py
@@ -1,29 +1,40 @@
 import datetime
 from fractions import Fraction
+from io import BytesIO
 from itertools import product
 from typing import Tuple
 
 import pytest
-from io import BytesIO
-
 import pytz
 
-from pyhanko.pdf_utils.generic import Reference, pdf_name
-from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
-from pyhanko.pdf_utils.layout import BoxSpecificationError, BoxConstraints
-from pyhanko.pdf_utils.reader import PdfFileReader, RawPdfPath
-from pyhanko.pdf_utils import writer, generic, misc
+from pyhanko.pdf_utils import generic, misc, writer
 from pyhanko.pdf_utils.content import (
-    ResourceType, PdfResources, ResourceManagementError
+    PdfResources,
+    ResourceManagementError,
+    ResourceType,
 )
 from pyhanko.pdf_utils.crypt import (
+    DEFAULT_CRYPT_FILTER,
+    STD_CF,
+    AuthStatus,
+    CryptFilterConfiguration,
+    IdentityCryptFilter,
+    PubKeyAdbeSubFilter,
+    PubKeyAESCryptFilter,
+    PubKeyRC4CryptFilter,
+    PubKeySecurityHandler,
+    SecurityHandler,
+    SecurityHandlerVersion,
+    StandardAESCryptFilter,
+    StandardRC4CryptFilter,
     StandardSecurityHandler,
-    StandardSecuritySettingsRevision, IdentityCryptFilter, AuthStatus,
-    PubKeySecurityHandler, SecurityHandlerVersion, CryptFilterConfiguration,
-    StandardRC4CryptFilter, StandardAESCryptFilter, STD_CF,
-    PubKeyRC4CryptFilter, PubKeyAESCryptFilter, PubKeyAdbeSubFilter,
-    DEFAULT_CRYPT_FILTER, build_crypt_filter, SecurityHandler,
+    StandardSecuritySettingsRevision,
+    build_crypt_filter,
 )
+from pyhanko.pdf_utils.generic import Reference, pdf_name
+from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+from pyhanko.pdf_utils.layout import BoxConstraints, BoxSpecificationError
+from pyhanko.pdf_utils.reader import PdfFileReader, RawPdfPath
 from pyhanko.pdf_utils.rw_common import PdfHandler
 from pyhanko.sign.general import load_cert_from_pemder
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pyyaml>=5.3.1
 cryptography>=3.3.1
 certomancer~=0.5.0
 uharfbuzz==0.16.1
+isort>=5.9.3

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import setup
 from os import path
+
+from setuptools import setup
 
 BASE_DIR = path.abspath(path.dirname(__file__))
 with open(path.join(BASE_DIR, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
This is just a suggestion - feel free to close it if it doesn't match your preference.

All source file diffs were created running `make format`.

It's currently using the `black` profile of isort to not cause additional changes if it's decided to go for the [black](https://black.readthedocs.io/) code formatter in the future (as a follow up question, would you be interested in applying that?).