### PR TITLE
Treat ASCII form feed (\f) as PDF whitespace

### DIFF
--- a/pyhanko/pdf_utils/misc.py
+++ b/pyhanko/pdf_utils/misc.py
@@ -73,7 +73,7 @@ def read_until_whitespace(stream, maxchars=None):
     return b''.join(_build())
 
 
-PDF_WHITESPACE = b' \n\r\t\x00'
+PDF_WHITESPACE = b' \n\r\t\f\x00'
 PDF_DELIMITERS = b'()<>[]{}/%'
 
 

--- a/pyhanko_tests/test_utils.py
+++ b/pyhanko_tests/test_utils.py
@@ -166,6 +166,15 @@ def test_mildly_malformed_xref_read():
     assert '/Pages' in root
 
 
+def test_whitespace_variants():
+    snippet_to_replace = b' /Pages 2 0 R'
+    assert snippet_to_replace in MINIMAL
+    for whitespace in [b' ', b'\n', b'\r', b'\t', b'\f']:
+        new_snippet = snippet_to_replace.replace(b' ', whitespace)
+        r = PdfFileReader(BytesIO(MINIMAL.replace(snippet_to_replace, new_snippet)))
+        pages = r.root['/Pages']['/Count'] == 1
+
+
 TEST_STRING = b'\x74\x77\x74\x84\x66'
 
 


### PR DESCRIPTION
According to "Table 1 — White-space characters" in ISO 32000-2:2020
an ASCII form feed (\f) character should be treated as whitespace.

Found by @avlidienbrunn