### PR TITLE
Use non-zero exit code on failed CLI validation

### DIFF
--- a/pyhanko/cli.py
+++ b/pyhanko/cli.py
@@ -520,7 +520,7 @@ def validate_signatures(ctx, infile, executive_summary,
                 print('\n\n' + status_str)
             else:
                 print('%s:%s:%s' % (name, fingerprint, status_str))
-            all_signatures_ok = all_signatures_ok and signature_ok
+            all_signatures_ok &= signature_ok
 
         if not all_signatures_ok:
             raise click.ClickException("Validation failed")


### PR DESCRIPTION
I think `pyhanko sign validate` should exit with a non-zero exit code if it fails validation.

This makes it more natural and easier to integrate into CI and shell scripts.