### PR TITLE
CSC protocol: aiohttp-based signer

### DIFF
--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -21,13 +21,21 @@ jobs:
           python -m pip install --upgrade pip
           python setup.py bdist_wheel
           pip install certomancer[web-api,pkcs12]==0.6.0 'pytest>=6.1.1' 'aiohttp>=3.7.4' \
-              'pytest-aiohttp~=0.3.0' dist/*.whl
+              'pytest-aiohttp~=0.3.0' dist/*.whl \
+               requests-mock~=1.8.0 freezegun~=1.1.0 python-pae==0.1.0
       - name: Start Certomancer Animator daemon
         run: |
           python -m certomancer --service-url-prefix http://localhost:9000 \
             --config pyhanko_tests/data/crypto/certomancer.yml animate &
+      - name: Start CSC dummy servers
+        run: |
+          python pyhanko_tests/csc_utils/csc_dummy_server.py \
+                  pyhanko_tests/data/crypto/certomancer.yml 8999 2 &
       - name: Test with pytest
         run: |
-          python -m pytest pyhanko_tests/with_live_certomancer.py
+          python -m pytest \
+                pyhanko_tests/with_live_certomancer.py \
+                pyhanko_tests/with_live_csc_dummy.py
         env:
           LIVE_CERTOMANCER_HOST_URL: http://localhost:9000
+          LIVE_CSC_SCAL2_HOST_URL: http://localhost:8999

--- a/docs/api-docs/pyhanko.sign.signers.csc_signer.rst
+++ b/docs/api-docs/pyhanko.sign.signers.csc_signer.rst
@@ -1,0 +1,7 @@
+pyhanko.sign.signers.csc_signer module
+======================================
+
+.. automodule:: pyhanko.sign.signers.csc_signer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api-docs/pyhanko.sign.signers.rst
+++ b/docs/api-docs/pyhanko.sign.signers.rst
@@ -7,6 +7,7 @@ pyhanko.sign.signers package
    :maxdepth: 4
 
    pyhanko.sign.signers.cms_embedder
+   pyhanko.sign.signers.csc_signer
    pyhanko.sign.signers.constants
    pyhanko.sign.signers.functions
    pyhanko.sign.signers.pdf_byterange

--- a/pyhanko/sign/signers/csc_signer.py
+++ b/pyhanko/sign/signers/csc_signer.py
@@ -19,7 +19,7 @@ from pyhanko.sign.general import SigningError, get_pyca_cryptography_hash
 
 try:
     import aiohttp
-except ImportError:
+except ImportError:   # pragma: nocover
     raise ImportError("Install pyHanko with [async_http]")
 
 logger = logging.getLogger(__name__)
@@ -117,6 +117,9 @@ def _process_certificate_info_response(response_data) -> CSCCredentialInfo:
     hash_pinning_required = scal_value == 2
 
     return CSCCredentialInfo(
+        # The CSC spec requires the signer's certificate to be first
+        # in the 'certs' array. The order for the others is unspecified,
+        # but that doesn't matter.
         signing_cert=certs[0], chain=certs[1:],
         supported_mechanisms=supported_algos,
         max_batch_size=max_batch_size,

--- a/pyhanko/sign/signers/csc_signer.py
+++ b/pyhanko/sign/signers/csc_signer.py
@@ -1,0 +1,354 @@
+import abc
+import asyncio
+import base64
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from asn1crypto import algos, x509
+from cryptography.hazmat.primitives import hashes
+from pyhanko_certvalidator.registry import (
+    CertificateStore,
+    SimpleCertificateStore,
+)
+
+from pyhanko.sign import Signer
+from pyhanko.sign.general import SigningError, get_pyca_cryptography_hash
+
+try:
+    import aiohttp
+except ImportError:
+    raise ImportError("Install pyHanko with [async_http]")
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CSCServiceSessionInfo:
+    service_url: str
+    credential_id: str
+    oauth_token: str
+    api_ver: str = 'v1'
+
+    def endpoint_url(self, endpoint_name):
+        return f"{self.service_url}/csc/{self.api_ver}/{endpoint_name}"
+
+    @property
+    def auth_headers(self):
+        return {'Authorization': f'Bearer {self.oauth_token}'}
+
+
+@dataclass(frozen=True)
+class CSCCredentialInfo:
+    signing_cert: x509.Certificate
+    chain: List[x509.Certificate]
+    supported_mechanisms: frozenset[str]
+    max_batch_size: int
+    hash_pinning_required: bool
+
+    def as_cert_store(self) -> CertificateStore:
+        scs = SimpleCertificateStore()
+        scs.register(self.signing_cert)
+        scs.register_multiple(self.chain)
+        return scs
+
+
+async def fetch_certs_in_csc_credential(session: aiohttp.ClientSession,
+                                        csc_session_info: CSCServiceSessionInfo,
+                                        timeout: int = 30) -> CSCCredentialInfo:
+    url = csc_session_info.endpoint_url("credentials/info")
+    req_data = {
+        "credentialID": csc_session_info.credential_id,
+        "certificates": "chain",
+        "certInfo": True
+    }
+
+    async with session.post(url=url, headers=csc_session_info.auth_headers,
+                            json=req_data, raise_for_status=True,
+                            timeout=timeout) as response:
+
+        try:
+            response_data = await response.json()
+        except aiohttp.ClientError as e:
+            raise SigningError("Credential info request failed") from e
+    return _process_certificate_info_response(response_data)
+
+
+def _process_certificate_info_response(response_data) -> CSCCredentialInfo:
+
+    try:
+        b64_certs = response_data['cert']['certificates']
+    except KeyError as e:
+        raise SigningError(
+            "Could not retrieve certificates from response"
+        ) from e
+    try:
+        certs = [
+            x509.Certificate.load(base64.b64decode(cert))
+            for cert in b64_certs
+        ]
+    except ValueError as e:
+        raise SigningError(
+            "Could not decode certificates in response"
+        ) from e
+    try:
+        algo_oids = response_data["key"]["algo"]
+        supported_algos = frozenset(
+            algos.SignedDigestAlgorithmId(oid).native for oid in algo_oids
+        )
+    except (KeyError, ValueError) as e:
+        raise SigningError(
+            "Could not retrieve supported signing mechanisms from response"
+        ) from e
+
+    try:
+        max_batch_size = int(response_data['multisign'])
+    except (KeyError, ValueError) as e:
+        raise SigningError(
+            "Could not retrieve max batch size from response"
+        ) from e
+
+    scal_value = int(response_data.get("SCAL", 1))
+    if scal_value not in (1, 2):
+        logger.warning(f"Unexpected SCAL value: {scal_value}; defaulting to 1")
+        scal_value = 1
+    hash_pinning_required = scal_value == 2
+
+    return CSCCredentialInfo(
+        signing_cert=certs[0], chain=certs[1:],
+        supported_mechanisms=supported_algos,
+        max_batch_size=max_batch_size,
+        hash_pinning_required=hash_pinning_required
+    )
+
+
+def base64_digest(data: bytes, digest_algorithm: str):
+
+    hash_spec = get_pyca_cryptography_hash(digest_algorithm)
+    md = hashes.Hash(hash_spec)
+    md.update(data)
+    return base64.b64encode(md.finalize()).decode('ascii')
+
+
+@dataclass(frozen=True)
+class CSCAuthorizationInfo:
+    sad: str
+    expires_at: Optional[datetime] = None
+
+
+class CSCAuthorizationManager(abc.ABC):
+
+    def __init__(self,
+                 csc_session_info: CSCServiceSessionInfo,
+                 credential_info: CSCCredentialInfo):
+        self.csc_session_info = csc_session_info
+        self.credential_info = credential_info
+
+    async def authorize_signature(self, hash_b64s: List[str]) \
+            -> CSCAuthorizationInfo:
+        """
+        Request a SAD from the signing service, either freshly or to extend
+        the current transaction.
+
+        Depending on the lifecycle of this object, pre-fetched SAD values
+        may be used. All authorization transaction management is left to
+        implementing subclasses.
+
+        :param hash_b64s:
+            Base64-encoded hash values about to be signed.
+        :return:
+            Authorization data.
+        """
+        raise NotImplementedError
+
+
+class PrefetchedSADAuthorizationManager(CSCAuthorizationManager):
+
+    def __init__(self, csc_session_info: CSCServiceSessionInfo,
+                 credential_info: CSCCredentialInfo,
+                 csc_auth_info: CSCAuthorizationInfo):
+        super().__init__(csc_session_info, credential_info)
+        self.csc_auth_info = csc_auth_info
+        self._used = False
+
+    async def authorize_signature(self,
+                                  hash_b64s: List[str]) -> CSCAuthorizationInfo:
+        if self._used:
+            raise SigningError("Prefetched SAD token is stale")
+        self._used = True
+        return self.csc_auth_info
+
+
+@dataclass
+class _CSCBatchInfo:
+    notifier: asyncio.Event
+    md_algorithm: str
+    b64_hashes: List[str] = field(default_factory=list)
+    initiated: bool = False
+    results: List[bytes] = None
+
+    def add(self, b64_hash: str) -> int:
+        ix = len(self.b64_hashes)
+        self.b64_hashes.append(b64_hash)
+        return ix
+
+
+class CSCSigner(Signer):
+
+    def __init__(self,
+                 session: aiohttp.ClientSession,
+                 auth_manager: CSCAuthorizationManager,
+                 sign_timeout: int,
+                 prefer_pss: bool = False, embed_roots: bool = True,
+                 client_data: Optional[str] = None,
+                 batch_autocommit: bool = True,
+                 batch_size: Optional[int] = None,
+                 est_raw_signature_size=512):
+
+        credential_info = auth_manager.credential_info
+        self.auth_manager = auth_manager
+        self.signing_cert = credential_info.signing_cert
+        self.cert_registry = credential_info.as_cert_store()
+        self.session = session
+        self.est_raw_signature_size = est_raw_signature_size
+        self.sign_timeout = sign_timeout
+        self.client_data = client_data
+        self.batch_autocommit = batch_autocommit
+        self._current_batch: Optional[_CSCBatchInfo] = None
+        if not batch_size:
+            batch_size = credential_info.max_batch_size
+        self.batch_size = batch_size
+        super().__init__(prefer_pss=prefer_pss, embed_roots=embed_roots)
+
+    def get_signature_mechanism(self, digest_algorithm):
+        if self.signature_mechanism is not None:
+            return self.signature_mechanism
+        result = super().get_signature_mechanism(digest_algorithm)
+        result_algo = result['algorithm']
+        supported = self.auth_manager.credential_info.supported_mechanisms
+        if result_algo.native not in supported:
+            raise SigningError(
+                f"Signature mechanism {result_algo.native} is not supported, "
+                f"must be one of {', '.join(alg for alg in supported)}."
+            )
+        return result
+
+    async def format_csc_signing_req(self, tbs_hashes: List[str],
+                                     digest_algorithm: str):
+
+        # Note: with asyncio events, it's possible to perform batch signing
+        # as well (out of scope for now)
+        mechanism = self.get_signature_mechanism(digest_algorithm)
+        session_info = self.auth_manager.csc_session_info
+        # SAD can be bound to specific hashes, but the authorization
+        # process typically takes more wall clock time (esp. when
+        # authorization requires a human user to perform an action).
+        # Putting get_activation_data in a separate coroutine
+        # allows API users to choose whether they want to provide
+        # the credentials at init time, or just-in-time tied to specific
+        # hashes.
+        # The latter might not scale as easily within this architecture;
+        # if you want both optimal security _and_ optimal performance,
+        # you'll have to use this signer in the interrupted signing workflow.
+        auth_info: CSCAuthorizationInfo \
+            = await self.auth_manager.authorize_signature(tbs_hashes)
+
+        req_data = {
+            'credentialID': session_info.credential_id,
+            'SAD': auth_info.sad,
+            'hashAlgo': algos.DigestAlgorithmId(digest_algorithm).dotted,
+            'signAlgo': mechanism['algorithm'].dotted,
+            'hash': tbs_hashes
+        }
+        if mechanism['parameters'].native is not None:
+            params_der = mechanism['parameters'].dump()
+            req_data['signAlgoParams'] = \
+                base64.b64encode(params_der).decode('ascii')
+        if self.client_data is not None:
+            req_data['clientData'] = self.client_data
+
+        return req_data
+
+    async def async_sign_raw(self, data: bytes, digest_algorithm: str,
+                             dry_run=False) -> bytes:
+        if dry_run:
+            return bytes(self.est_raw_signature_size)
+
+        tbs_hash = base64_digest(data, digest_algorithm)
+        if self._current_batch is None:
+            self._current_batch = batch = _CSCBatchInfo(
+                notifier=asyncio.Event(),
+                md_algorithm=digest_algorithm,
+            )
+        else:
+            batch = self._current_batch
+            if batch.md_algorithm != digest_algorithm:
+                raise SigningError(
+                    f"All signatures in the same batch must use the same digest"
+                    f"function; encountered both {batch.md_algorithm} "
+                    f"and {digest_algorithm}."
+                )
+        ix = batch.add(tbs_hash)
+        # autocommit if the batch is full
+        if self.batch_autocommit and ix == self.batch_size - 1:
+            try:
+                await self.commit()
+            except SigningError as e:
+                # log and move on, we'll throw a regular exception later
+                logger.error("Failed to commit signatures", exc_info=e)
+
+        # Sleep until a commit goes through
+        await batch.notifier.wait()
+        if not batch.results:
+            raise SigningError("No signing results available")
+        return batch.results[ix]
+
+    async def commit(self):
+        batch = self._current_batch
+        if batch is None:
+            raise SigningError("There is no batch to sign")
+        if batch.results is not None:
+            return
+        elif batch.initiated:
+            # just wait for the commit to finish together with
+            # all the signers in the queue
+            await batch.notifier.wait()
+            if not batch.results:
+                raise SigningError("Commit failed")
+        else:
+            batch.initiated = True
+            try:
+                await self._do_commit(batch)
+            finally:
+                self._current_batch = None
+
+    async def _do_commit(self, batch: _CSCBatchInfo):
+        req_data = await self.format_csc_signing_req(
+            batch.b64_hashes, batch.md_algorithm
+        )
+        session_info = self.auth_manager.csc_session_info
+        url = session_info.endpoint_url("signatures/signHash")
+        session = self.session
+        try:
+            async with session.post(url=url, headers=session_info.auth_headers,
+                                    json=req_data, raise_for_status=True,
+                                    timeout=self.sign_timeout) as response:
+                response_data = await response.json()
+            sig_b64s = response_data['signatures']
+            actual_len = len(sig_b64s)
+            expected_len = len(batch.b64_hashes)
+            if actual_len != expected_len:
+                raise SigningError(
+                    f"Expected {expected_len} signatures, got {actual_len}"
+                )
+            signatures = [base64.b64decode(sig) for sig in sig_b64s]
+            batch.results = signatures
+        except (ValueError, KeyError) as e:
+            raise SigningError(
+                "Expected response with b64-encoded signature values"
+            ) from e
+        except aiohttp.ClientError as e:
+            raise SigningError("Signature request failed") from e
+        finally:
+            batch.notifier.set()

--- a/pyhanko/sign/signers/csc_signer.py
+++ b/pyhanko/sign/signers/csc_signer.py
@@ -1,3 +1,84 @@
+"""
+Asynchronous :class:`~pyhanko.sign.signers.pdf_cms.Signer` implementation for
+interacting with a remote signing service using the Cloud Signature Consortium
+(CSC) API.
+
+This implementation is based on version 1.0.4.0 (2019-06) of the CSC API
+specification.
+
+
+Usage notes
+-----------
+
+This module's :class:`.CSCSigner` class supplies an implementation of the
+:class:`~pyhanko.sign.signers.pdf_cms.Signer` class in pyHanko.
+As such, it is flexible enough to be used either through pyHanko's high-level
+API (:func:`~pyhanko.sign.signers.functions.sign_pdf` et al.), or through
+the :ref:`interrupted signing API <interrupted-signing>`.
+
+:class:`.CSCSigner` overview
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:class:`.CSCSigner` is only directly responsible for calling the
+``signatures/signHash`` endpoint in the CSC API. Other than that, it only
+handles batch control. This means that the following tasks require further
+action on the API user's part:
+
+ * authenticating to the signing service (typically using OAuth2);
+ * obtaining Signature Activation Data (SAD) from the signing service;
+ * provisioning the certificates to embed into the document (usually
+   those are supplied by the signing service as well).
+
+The first two involve a degree of implementation/vendor dependence that is
+difficult to cater to in full generality, and the third is out of scope
+for :class:`~pyhanko.sign.signers.pdf_cms.Signer` subclasses in general.
+
+However, this module still provides a number of convenient hooks and guardrails
+that should allow you to fill in these blanks with relative ease. We briefly
+discuss these below.
+
+Throughout, the particulars of how pyHanko should connect to a signing
+service are supplied in a :class:`.CSCServiceSessionInfo` object.
+This object contains the base CSC API URL, the CSC credential ID to use,
+and authentication data.
+
+
+Authenticating to the signing service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While the authentication process itself is the API user's responsibility,
+:class:`.CSCServiceSessionInfo` includes an
+:attr:`~.CSCServiceSessionInfo.oauth_token` field that will (by default)
+be used to populate the HTTP ``Authorization`` header for every request.
+
+To handle OAuth-specific tasks, you might want to use a library like
+`OAuthLib <https://oauthlib.readthedocs.io/en/latest/>`_.
+
+
+Obtaining SAD from the signing service
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is done by subclassing :class:`.CSCAuthorizationInfo` and passing
+an instance to the :class:`.CSCSigner`. The :class:`.CSCAuthorizationInfo`
+instance should call the signer's ``credentials/authorize`` endpoint with
+the proper parameters required by the service.
+See the documentation for :class:`.CSCAuthorizationInfo` for details and=
+information about helper functions.
+
+
+Certificate provisioning
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+In pyHanko's API, :class:`~pyhanko.sign.signers.pdf_cms.Signer` instances
+need to be initialised with the signer's certificate, preferably together
+with other relevant CA certificates.
+In a CSC context, these are typically retrieved from the signing service by
+calling the ``credentials/info`` endpoint.
+
+This module offers a helper function to handle that task, see
+:func:`.fetch_certs_in_csc_credential`.
+"""
+
 import abc
 import asyncio
 import base64
@@ -22,33 +103,124 @@ try:
 except ImportError:   # pragma: nocover
     raise ImportError("Install pyHanko with [async_http]")
 
+__all__ = [
+    'CSCSigner',
+    'CSCServiceSessionInfo', 'CSCCredentialInfo',
+    'fetch_certs_in_csc_credential', 'CSCAuthorizationInfo',
+    'CSCAuthorizationManager', 'PrefetchedSADAuthorizationManager'
+]
+
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class CSCServiceSessionInfo:
+    """
+    Information about the CSC service, together with the required authentication
+    data.
+    """
+
     service_url: str
+    """
+    Base URL of the CSC service. This is the part that precedes
+    ``/csc/<version>/...`` in the API endpoint URLs.
+    """
+
     credential_id: str
-    oauth_token: str
+    """
+    The identifier of the CSC credential to use when signing.
+    The format is vendor-dependent.
+    """
+
+    oauth_token: Optional[str] = None
+    """
+    OAuth token to use when making requests to the CSC service.
+    """
+
     api_ver: str = 'v1'
+    """
+    CSC API version.
+
+    .. note::
+        This section does not affect any of the internal logic, it only changes
+        how the URLs are formatted.
+    """
 
     def endpoint_url(self, endpoint_name):
+        """
+        Complete an endpoint name to a full URL.
+
+        :param endpoint_name:
+            Name of the endpoint (e.g. ``credentials/info``).
+        :return:
+            A URL.
+        """
         return f"{self.service_url}/csc/{self.api_ver}/{endpoint_name}"
 
     @property
     def auth_headers(self):
-        return {'Authorization': f'Bearer {self.oauth_token}'}
+        """
+        HTTP Header(s) necessary for authentication, to be passed with every
+        request.
+
+        .. note::
+            By default, this supplies the ``Authorization`` header
+            with the value of :attr:`oauth_token` as the ``Bearer`` value.
+
+        :return:
+            A ``dict`` of headers.
+        """
+
+        tok = self.oauth_token
+        return {'Authorization': f'Bearer {tok}'} if tok else {}
 
 
 @dataclass(frozen=True)
 class CSCCredentialInfo:
+    """
+    Information about a CSC credential, typically fetched using a
+    ``credentials/info`` call. See also :func:`.fetch_certs_in_csc_credential`.
+    """
+
     signing_cert: x509.Certificate
+    """
+    The signer's certificate.
+    """
+
     chain: List[x509.Certificate]
+    """
+    Other relevant CA certificates.
+    """
+
     supported_mechanisms: frozenset[str]
+    """
+    Signature mechanisms supported by the credential.
+    """
+
     max_batch_size: int
+    """
+    The maximal batch size that can be used with this credential.
+    """
+
     hash_pinning_required: bool
+    """
+    Flag controlling whether SAD must be tied to specific hashes.
+    """
+
+    response_data: dict
+    """
+    The JSON response data from the server as an otherwise unparsed ``dict``.
+    """
 
     def as_cert_store(self) -> CertificateStore:
+        """
+        Register the relevant certificates into a :class:`.CertificateStore`
+        and return it.
+
+        :return:
+            A :class:`.CertificateStore`.
+        """
+
         scs = SimpleCertificateStore()
         scs.register(self.signing_cert)
         scs.register_multiple(self.chain)
@@ -58,6 +230,20 @@ class CSCCredentialInfo:
 async def fetch_certs_in_csc_credential(session: aiohttp.ClientSession,
                                         csc_session_info: CSCServiceSessionInfo,
                                         timeout: int = 30) -> CSCCredentialInfo:
+    """
+    Call the ``credentials/info`` endpoint of the CSC service for a specific
+    credential, and encode the result into a :class:`.CSCCredentialInfo`
+    object.
+
+    :param session:
+        The ``aiohttp`` session to use when performing queries.
+    :param csc_session_info:
+        General information about the CSC service and the credential.
+    :param timeout:
+        How many seconds to allow before time-out.
+    :return:
+        A :class:`.CSCCredentialInfo` object with the processed response.
+    """
     url = csc_session_info.endpoint_url("credentials/info")
     req_data = {
         "credentialID": csc_session_info.credential_id,
@@ -68,11 +254,11 @@ async def fetch_certs_in_csc_credential(session: aiohttp.ClientSession,
     async with session.post(url=url, headers=csc_session_info.auth_headers,
                             json=req_data, raise_for_status=True,
                             timeout=timeout) as response:
-
         try:
             response_data = await response.json()
         except aiohttp.ClientError as e:
             raise SigningError("Credential info request failed") from e
+
     return _process_certificate_info_response(response_data)
 
 
@@ -123,11 +309,22 @@ def _process_certificate_info_response(response_data) -> CSCCredentialInfo:
         signing_cert=certs[0], chain=certs[1:],
         supported_mechanisms=supported_algos,
         max_batch_size=max_batch_size,
-        hash_pinning_required=hash_pinning_required
+        hash_pinning_required=hash_pinning_required,
+        response_data=response_data
     )
 
 
-def base64_digest(data: bytes, digest_algorithm: str):
+def base64_digest(data: bytes, digest_algorithm: str) -> str:
+    """
+    Digest some bytes and base64-encode the result.
+
+    :param data:
+        Data to digest.
+    :param digest_algorithm:
+        Name of the digest algorihtm to use.
+    :return:
+        A base64-encoded hash.
+    """
 
     hash_spec = get_pyca_cryptography_hash(digest_algorithm)
     md = hashes.Hash(hash_spec)
@@ -137,11 +334,37 @@ def base64_digest(data: bytes, digest_algorithm: str):
 
 @dataclass(frozen=True)
 class CSCAuthorizationInfo:
+    """
+    Authorization data to make a signing request.
+    This is the result of a call to ``credentials/authorize``.
+    """
+
     sad: str
+    """
+    Signature activation data; opaque to the client.
+    """
+
     expires_at: Optional[datetime] = None
+    """
+    Expiry date of the signature activation data.
+    """
 
 
 class CSCAuthorizationManager(abc.ABC):
+    """
+    Abstract class that handles authorisation requests for the CSC signing
+    client.
+
+    .. note::
+        Implementations may wish to make use of the
+        :meth:`format_csc_auth_request` convenience method to format
+        requests to the ``credentials/authorize`` endpoint.
+
+    :param csc_session_info:
+        General information about the CSC service and the credential.
+    :param credential_info:
+        Details about the credential.
+    """
 
     def __init__(self,
                  csc_session_info: CSCServiceSessionInfo,
@@ -152,8 +375,8 @@ class CSCAuthorizationManager(abc.ABC):
     async def authorize_signature(self, hash_b64s: List[str]) \
             -> CSCAuthorizationInfo:
         """
-        Request a SAD from the signing service, either freshly or to extend
-        the current transaction.
+        Request a SAD token from the signing service, either freshly or to
+        extend the current transaction.
 
         Depending on the lifecycle of this object, pre-fetched SAD values
         may be used. All authorization transaction management is left to
@@ -172,6 +395,29 @@ class CSCAuthorizationManager(abc.ABC):
                                 hash_b64s: Optional[List[str]] = None,
                                 description: Optional[str] = None,
                                 client_data: Optional[str] = None) -> dict:
+        """
+        Format the parameters for a call to ``credentials/authorize``.
+
+        :param num_signatures:
+            The number of signatures to request authorisation for.
+        :param pin:
+            The user's PIN (if applicable).
+        :param otp:
+            The current value of an OTP token, provided by the user
+            (if applicable).
+        :param hash_b64s:
+            An explicit list of base64-encoded hashes to be tied to the SAD.
+            Is optional if the service's SCAL value is 1, i.e.
+            when :attr:`~.CSCCredentialInfo.hash_pinning_required` is false.
+        :param description:
+            A free-form description of the authorisation request
+            (optional).
+        :param client_data:
+            Custom vendor-specific data (if applicable).
+        :return:
+            A dict that, when encoded as a JSON object, be used as the request
+            body for a call to ``credentials/authorize``.
+        """
         result = {'credentialID': self.csc_session_info.credential_id}
 
         if hash_b64s is not None:
@@ -195,6 +441,15 @@ class CSCAuthorizationManager(abc.ABC):
 
     @staticmethod
     def parse_csc_auth_response(response_data: dict) -> CSCAuthorizationInfo:
+        """
+        Parse the response from a ``credentials/authorize`` call into
+        a :class:`.CSCAuthorizationInfo` object.
+
+        :param response_data:
+            The decoded response JSON.
+        :return:
+            A :class:`.CSCAuthorizationInfo` object.
+        """
 
         try:
             sad = response_data["SAD"]
@@ -217,10 +472,42 @@ class CSCAuthorizationManager(abc.ABC):
 
     @property
     def auth_headers(self):
+        """
+        HTTP Header(s) necessary for authentication, to be passed with every
+        request. By default, this delegates to
+        :attr:`.CSCServiceSessionInfo.auth_headers`.
+
+        :return:
+            A ``dict`` of headers.
+        """
         return self.csc_session_info.auth_headers
 
 
 class PrefetchedSADAuthorizationManager(CSCAuthorizationManager):
+    """
+    Simplistic :class:`.CSCAuthorizationManager` for use with pre-fetched
+    signature activation data.
+
+    This class is effectively only useful for CSC services that do not require
+    SAD to be pinned to specific document hashes. It allows you to use a SAD
+    that was fetched before starting the signing process, for a one-shot
+    signature.
+
+    This can simplify resource management in cases where obtaining a
+    SAD is time-consuming, but the caller still wants the conveniences of
+    pyHanko's high-level API without having to keep too many pyHanko objects
+    in memory while waiting for a ``credentials/authorize`` call to go through.
+
+    Legitimate uses are limited, but the implementation is trivial, so we
+    provide it here.
+
+    :param csc_session_info:
+        General information about the CSC service and the credential.
+    :param credential_info:
+        Details about the credential.
+    :param csc_auth_info:
+        The pre-fetched signature activation data.
+    """
 
     def __init__(self, csc_session_info: CSCServiceSessionInfo,
                  credential_info: CSCCredentialInfo,
@@ -231,6 +518,14 @@ class PrefetchedSADAuthorizationManager(CSCAuthorizationManager):
 
     async def authorize_signature(self,
                                   hash_b64s: List[str]) -> CSCAuthorizationInfo:
+        """
+        Return the prefetched SAD, or raise an error if called twice.
+
+        :param hash_b64s:
+            List of hashes to be signed; ignored.
+        :return:
+            The prefetched authorisation data.
+        """
         if self._used:
             raise SigningError("Prefetched SAD token is stale")
         self._used = True
@@ -239,10 +534,31 @@ class PrefetchedSADAuthorizationManager(CSCAuthorizationManager):
 
 @dataclass
 class _CSCBatchInfo:
+    """
+    Internal value type to track batch control data.
+    """
+
     notifier: asyncio.Event
+    """
+    Event object used to notify waiting coroutines that the batch has
+    been committed.
+    """
+
     md_algorithm: str
+    """
+    The digest algorithm that was used for the entire batch.
+    """
+
     b64_hashes: List[str] = field(default_factory=list)
+    """
+    List of base64-encoded hashes to sign.
+    """
+
     initiated: bool = False
+    """
+    Flag indicating whether the commit process has been started.
+    """
+
     results: List[bytes] = None
 
     def add(self, b64_hash: str) -> int:
@@ -252,11 +568,46 @@ class _CSCBatchInfo:
 
 
 class CSCSigner(Signer):
+    """
+    Implements the :class:`~pyhanko.sign.signers.pdf_cms.Signer` interface
+    for a remote CSC signing service.
+    Requests are made asynchronously, using ``aiohttp``.
+
+    :param session:
+        The ``aiohttp`` session to use when performing queries.
+    :param auth_manager:
+        A :class:`.CSCAuthorizationManager` instance capable of procuring
+        signature activation data from the signing service.
+    :param sign_timeout:
+        Timeout for signing operations, in seconds.
+        Defaults to 300 seconds (5 minutes).
+    :param prefer_pss:
+        When signing using an RSA key, prefer PSS padding to legacy PKCS#1 v1.5
+        padding. Default is ``False``. This option has no effect on non-RSA
+        signatures.
+    :param embed_roots:
+        Option that controls whether or not additional self-signed certificates
+        should be embedded into the CMS payload. The default is ``True``.
+    :param client_data:
+        CSC client data to add to any signing request(s), if applicable.
+    :param batch_autocommit:
+        Whether to automatically commit a signing transaction as soon as a
+        batch is full. The default is ``True``.
+        If ``False``, the caller has to trigger :meth:`commit` manually.
+    :param batch_size:
+        The number of signatures to sign in one transaction.
+        This defaults to 1 (i.e. a separate ``signatures/signHash`` call is made
+        for every signature).
+    :param est_raw_signature_size:
+        Estimated raw signature size (in bytes). Defaults to 512 bytes, which,
+        combined with other built-in safety margins, should provide a generous
+        overestimate.
+    """
 
     def __init__(self,
                  session: aiohttp.ClientSession,
                  auth_manager: CSCAuthorizationManager,
-                 sign_timeout: int,
+                 sign_timeout: int = 300,
                  prefer_pss: bool = False, embed_roots: bool = True,
                  client_data: Optional[str] = None,
                  batch_autocommit: bool = True,
@@ -273,9 +624,7 @@ class CSCSigner(Signer):
         self.client_data = client_data
         self.batch_autocommit = batch_autocommit
         self._current_batch: Optional[_CSCBatchInfo] = None
-        if not batch_size:
-            batch_size = credential_info.max_batch_size
-        self.batch_size = batch_size
+        self.batch_size = batch_size or 1
         super().__init__(prefer_pss=prefer_pss, embed_roots=embed_roots)
 
     def get_signature_mechanism(self, digest_algorithm):
@@ -292,7 +641,18 @@ class CSCSigner(Signer):
         return result
 
     async def format_csc_signing_req(self, tbs_hashes: List[str],
-                                     digest_algorithm: str):
+                                     digest_algorithm: str) -> dict:
+        """
+        Populate the request data for a CSC signing request
+
+        :param tbs_hashes:
+            Base64-encoded hashes that require signing.
+        :param digest_algorithm:
+            The digest algorithm to use.
+        :return:
+            A dict that, when encoded as a JSON object, be used as the request
+            body for a call to ``signatures/signHash``.
+        """
 
         mechanism = self.get_signature_mechanism(digest_algorithm)
         session_info = self.auth_manager.csc_session_info
@@ -360,6 +720,15 @@ class CSCSigner(Signer):
         return batch.results[ix]
 
     async def commit(self):
+        """
+        Commit the current batch by calling the ``signatures/signHash`` endpoint
+        on the CSC service.
+
+        This coroutine does not return anything; instead, it notifies all
+        waiting signing coroutines that their signature has been fetched.
+        Errors are propagated to the waiting signers as well.
+        """
+
         batch = self._current_batch
         if batch is None or batch.results is not None:
             return
@@ -377,6 +746,11 @@ class CSCSigner(Signer):
                 self._current_batch = None
 
     async def _do_commit(self, batch: _CSCBatchInfo):
+        """
+        Internal commit routine that skips error handling and concurrency
+        checks.
+        """
+
         req_data = await self.format_csc_signing_req(
             batch.b64_hashes, batch.md_algorithm
         )

--- a/pyhanko_tests/csc_utils/csc_dummy_client.py
+++ b/pyhanko_tests/csc_utils/csc_dummy_client.py
@@ -1,0 +1,79 @@
+import asyncio
+from typing import List
+
+import aiohttp
+
+from pyhanko.sign.general import SigningError
+from pyhanko.sign.signers.csc_signer import (
+    CSCAuthorizationInfo,
+    CSCAuthorizationManager,
+    CSCServiceSessionInfo,
+    CSCSigner,
+    fetch_certs_in_csc_credential,
+)
+
+
+class CSCDummyClientAuthManager(CSCAuthorizationManager):
+    def __init__(self, session, session_info, credential_info, waste_time=0):
+        self.session = session
+        super().__init__(
+            csc_session_info=session_info,
+            credential_info=credential_info
+        )
+        self.authorizations_requested = 0
+        self.waste_time = waste_time
+
+    async def authorize_signature(self,
+                                  hash_b64s: List[str]) -> CSCAuthorizationInfo:
+        self.authorizations_requested += 1
+        session_info = self.csc_session_info
+        req_data = self.format_csc_auth_request(hash_b64s=hash_b64s)
+        session = self.session
+
+        url = session_info.endpoint_url("credentials/authorize")
+        async with session.post(url, headers=self.auth_headers,
+                                json=req_data, raise_for_status=True,
+                                timeout=30) as response:
+            try:
+                response_data = await response.json()
+            except aiohttp.ClientError as e:
+                raise SigningError("Credential auth request failed") from e
+
+        if self.waste_time:
+            await asyncio.sleep(self.waste_time)
+        return self.parse_csc_auth_response(response_data)
+
+
+class CSCDummy:
+    def __init__(self, endpoint_url, credential_id, timeout: int,
+                 waste_time=0, **signer_kwargs):
+        self.timeout = timeout
+        self.svc_info = CSCServiceSessionInfo(
+            service_url=endpoint_url,
+            credential_id=credential_id,
+            oauth_token='deadbeef',
+            api_ver='v1'
+        )
+        self.waste_time = waste_time
+        self.signer_kwargs = signer_kwargs
+        self.session = None
+
+    async def __aenter__(self):
+        svc_info = self.svc_info
+        self.session = session = aiohttp.ClientSession()
+        creds = await fetch_certs_in_csc_credential(
+            session=session, csc_session_info=svc_info
+        )
+        auth_manager = CSCDummyClientAuthManager(
+            session, svc_info, credential_info=creds,
+            waste_time=self.waste_time
+        )
+        signer = CSCSigner(
+            session, auth_manager=auth_manager,
+            sign_timeout=self.timeout, **self.signer_kwargs
+        )
+        return signer
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self.session is not None:
+            await self.session.close()

--- a/pyhanko_tests/csc_utils/csc_dummy_server.py
+++ b/pyhanko_tests/csc_utils/csc_dummy_server.py
@@ -1,0 +1,543 @@
+"""
+Dummy CSC server implementation.
+
+This is a testing tool, and it omits all sorts of essential security features:
+
+ - Requests are not authenticated
+ - No SAD replay prevention of any sort, other than the standard hash pinning
+   supported by the CSC protocol
+ - All keys in the Certomancer config can be used to sign hashes in CSC calls
+
+It goes without saying that you should never use this implementation, or any
+derivative thereof, with production keys.
+"""
+
+import base64
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import List, Optional
+
+import python_pae
+from aiohttp import web
+from asn1crypto import algos, keys
+from certomancer import registry
+from certomancer.config_utils import ConfigurationError
+from certomancer.registry import (
+    ArchLabel,
+    CertLabel,
+    CertomancerObjectNotFoundError,
+)
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, hmac
+from python_pae.encode import PAEListSettings, read_pae_coro
+from python_pae.pae_types import (
+    PAE_UCHAR,
+    PAE_UINT,
+    PAE_USHORT,
+    PAEBytes,
+    PAEHeterogeneousList,
+    PAEHomogeneousList,
+    PAEString,
+)
+
+# FIXME machine-readable error messages
+
+# TODO implement extendTransaction since it is relevant for PDF
+
+
+API_VERSION = '1.0.3.0'
+DEFAULT_NAME = 'Certomancer CSC test'
+DEFAULT_DESCRIPTION = """
+Dummy CSC implementation for integration testing purposes.
+"""
+
+# FIXME use a url that actually resolves to an image
+DEFAULT_LOGO = 'http://example.com/logo.png'
+
+
+@dataclass(frozen=True)
+class GeneralServiceInfo:
+    api_version: str = API_VERSION
+    name: str = DEFAULT_NAME
+    logo: str = DEFAULT_LOGO
+    region_code: str = 'XX'
+    lang_code: str = 'en'
+    description: str = DEFAULT_DESCRIPTION.strip()
+    auth_type: List[str] = field(default_factory=lambda: ['external'])
+    oauth_uri: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DummyServiceParams:
+    hash_pinning_required: bool = True
+    multisign: int = 10
+    sad_secret: bytes = b'secret'
+
+
+_CSC_AUTH_HASHES_LIST_PAE_TYPE = PAEHomogeneousList(
+    child_type=PAEBytes(),
+    settings=PAEListSettings(size_type=PAE_USHORT)
+)
+
+_CSC_AUTH_FULL_TOKEN_PAE_TYPE = PAEHeterogeneousList(
+    [PAEString(), PAEBytes()],
+    settings=PAEListSettings(
+        size_type=PAE_UCHAR,
+        length_type=PAE_UINT
+    )
+)
+
+
+def _csc_auth_pae_embedded(obj: 'CSCAuthorization'):
+    # this travels with the token
+    embedded_parts = [(obj.num_signatures, PAE_USHORT)]
+    if obj.hashes is not None:
+        embedded_parts.append((obj.hashes, _CSC_AUTH_HASHES_LIST_PAE_TYPE))
+    return python_pae.pae_encode_multiple(
+        embedded_parts, size_t=PAE_UINT
+    )
+
+
+def _csc_auth_pae_parse(embedded_payload: bytes, credential_id: str):
+    reader = read_pae_coro(
+        BytesIO(embedded_payload),
+        settings=PAEListSettings(size_type=PAE_UINT)
+    )
+    elements = next(reader)
+    if elements not in (1, 2):
+        raise python_pae.PAEDecodeError("Expected one or two elements")
+
+    num_signatures = reader.send(PAE_USHORT)
+    if elements == 2:
+        hashes_list = reader.send(_CSC_AUTH_HASHES_LIST_PAE_TYPE)
+        if len(hashes_list) != num_signatures:
+            raise ValueError("Length of hashes does not match signature")
+    else:
+        hashes_list = None
+    return CSCAuthorization(
+        credential_id=credential_id,
+        num_signatures=num_signatures,
+        hashes=hashes_list
+    )
+
+
+def _csc_auth_pae(credential_id: str, embedded_payload: bytes):
+    return python_pae.marshal(
+        [credential_id, embedded_payload], _CSC_AUTH_FULL_TOKEN_PAE_TYPE
+    )
+
+
+@dataclass(frozen=True)
+class CSCAuthorization:
+    # TODO implement expiry
+
+    credential_id: str
+    num_signatures: int
+    hashes: Optional[List[bytes]]
+
+    @property
+    def as_dict(self) -> dict:
+        result = {
+            'credential_id': self.credential_id,
+            'num_signatures': self.num_signatures,
+        }
+        if self.hashes is not None:
+            result['hashes'] = [
+                base64.b64encode(x).decode('ascii') for x in self.hashes
+            ]
+        return result
+
+    def derive_sad(self, secret: bytes) -> str:
+        # noinspection PyTypeChecker
+        h = hmac.HMAC(secret, hashes.SHA256())
+        embedded_payload = _csc_auth_pae_embedded(self)
+        input_for_mac = _csc_auth_pae(self.credential_id, embedded_payload)
+        h.update(input_for_mac)
+        mac_token = h.finalize()
+
+        # Put the token together with the embedded payload
+        full_token = python_pae.pae_encode(
+            [embedded_payload, mac_token],
+            size_t=PAE_UINT
+        )
+        # ...and base64 the lot
+        return base64.b64encode(full_token).decode('ascii')
+
+    @classmethod
+    def verify_sad(cls, sad: str, secret: bytes, credential_id: str) \
+            -> 'CSCAuthorization':
+        decoded = base64.b64decode(sad)
+        try:
+            embedded_auth_data, mac_token = python_pae.unmarshal(
+                decoded, PAEHomogeneousList(
+                    child_type=PAEBytes(),
+                    settings=PAEListSettings(size_type=PAE_UINT)
+                )
+            )
+        except ValueError:
+            raise web.HTTPBadRequest()
+        # validate the MAC first, before trying to process the auth data
+        # noinspection PyTypeChecker
+        h = hmac.HMAC(secret, hashes.SHA256())
+        h.update(_csc_auth_pae(credential_id, embedded_auth_data))
+        try:
+            h.verify(mac_token)
+        except InvalidSignature:
+            raise web.HTTPBadRequest()
+        try:
+            auth_data_obj = \
+                _csc_auth_pae_parse(embedded_auth_data, credential_id)
+        except ValueError:
+            raise web.HTTPBadRequest()
+        return auth_data_obj
+
+
+ALGO_SUPPORT = {
+    'rsa': {
+        'rsassa_pkcs1v15', 'rsassa_pss',
+        'sha256_rsa', 'sha384_rsa', 'sha512_rsa'
+    },
+    'ec': {'sha256_ecdsa', 'sha384_ecdsa', 'sha512_ecdsa'},
+}
+
+
+def b64_der(obj) -> str:
+    return base64.b64encode(obj.dump()).decode('ascii')
+
+
+# noinspection PyUnusedLocal
+class CSCWithCertomancer:
+
+    def __init__(self, certomancer_config: registry.CertomancerConfig,
+                 svc_info: GeneralServiceInfo = GeneralServiceInfo(),
+                 service_params: DummyServiceParams = DummyServiceParams()):
+        self.app = web.Application()
+        self.app['certomancer_config'] = certomancer_config
+        self.app['svc_info'] = svc_info
+        self.app['service_params'] = service_params
+
+    def register_routes(self):
+        self.app.add_routes([
+            web.get('/info', self.info),
+            web.post('/csc/v1/info', self.info),
+            # we don't implement the auth/... endpoints
+            web.post('/csc/v1/credentials/list', self.credentials_list),
+            web.post('/csc/v1/credentials/info', self.credentials_info),
+            web.post('/csc/v1/credentials/authorize', self.credentials_authorize),
+            # we don't do extendTransaction and sendOTP
+            web.post('/csc/v1/signatures/signHash', self.signatures_sign_hash),
+            # TODO implement /signatures/timestamp
+        ])
+
+    @property
+    def svc_info(self) -> GeneralServiceInfo:
+        return self.app['svc_info']
+
+    @property
+    def service_params(self) -> DummyServiceParams:
+        return self.app['service_params']
+
+    @property
+    def certomancer_config(self) -> registry.CertomancerConfig:
+        return self.app['certomancer_config']
+
+    async def info(self, request: web.Request):
+        svc_info = self.svc_info
+        result = {
+            'specs': API_VERSION,
+            'name': svc_info.name, 'logo': svc_info.logo,
+            'region': svc_info.region_code, 'lang': svc_info.lang_code,
+            'description': svc_info.description,
+            'authType': svc_info.auth_type,
+            'methods': [
+                'credentials/info', 'credentials/list', 'credentials/authorize',
+                'signatures/signHash', 'signatures/timestamp'
+            ]
+        }
+        if svc_info.oauth_uri:
+            result['oauth2'] = svc_info.oauth_uri
+        return web.json_response(result)
+
+    async def credentials_list(self, request: web.Request):
+        params = await request.json()
+        config = self.certomancer_config
+
+        def enumerate_arch(arch_label: ArchLabel):
+            try:
+                pki_arch = config.get_pki_arch(arch_label)
+            except ConfigurationError:
+                raise web.HTTPBadRequest()
+            for iss, certs in pki_arch.enumerate_certs_by_issuer():
+                for cert_spec in certs:
+                    yield cert_spec.label
+
+        # we don't do pagination
+        arch = params.get('clientData', None)
+        if arch is None:
+            archs = config.pki_archs.keys()
+        else:
+            archs = (arch,)
+        all_credentials = [
+            f"{arch_label}/{cert_label}"
+            for arch_label in archs for cert_label in enumerate_arch(arch_label)
+        ]
+        return web.json_response({'credentialIDs': all_credentials})
+
+    def _parse_credential_id(self, cred_id):
+        splits = cred_id.split(sep='/', maxsplit=1)
+        arch_label = ArchLabel(splits[0])
+        try:
+            cert_label = CertLabel(splits[1])
+        except IndexError:
+            raise web.HTTPNotFound()
+
+        config = self.certomancer_config
+        try:
+            pki_arch = config.get_pki_arch(arch_label)
+            cert_spec = pki_arch.get_cert_spec(cert_label)
+        except CertomancerObjectNotFoundError:
+            raise web.HTTPNotFound()
+        return pki_arch, cert_spec
+
+    async def credentials_info(self, request: web.Request):
+        params = await request.json()
+        cert_info_req = params.get('certInfo', False)
+
+        # TODO implement certInfo
+        #  (biggest roadblock: asn1crypto doesn't implement RFC 4514)
+        if cert_info_req:
+            raise web.HTTPNotImplemented()
+        config = self.certomancer_config
+        try:
+            cred_id = str(params['credentialID'])
+        except KeyError:
+            raise web.HTTPBadRequest()
+
+        pki_arch, cert_spec = self._parse_credential_id(cred_id)
+        cert = pki_arch.get_cert(cert_spec.label)
+        subj_pub_key: keys.PublicKeyInfo = cert.public_key
+        enabled = pki_arch.is_subject_key_available(cert_spec.label)
+        key_info = {
+            'status': "enabled" if enabled else "disabled",
+            'algo': [
+                algos.SignedDigestAlgorithmId(algo).dotted
+                for algo in ALGO_SUPPORT.get(subj_pub_key.algorithm, ())
+            ],
+            'len': subj_pub_key.bit_size,
+        }
+        if subj_pub_key.algorithm == 'ec':
+            ec_params: keys.ECDomainParameters = \
+                subj_pub_key['algorithm']['parameters']
+            if ec_params.name == 'named':
+                key_info['curve'] = ec_params.chosen.dotted
+
+        certificates_req = params.get('certificates', 'single')
+        if certificates_req not in ('none', 'chain', 'single'):
+            raise web.HTTPBadRequest()
+        response = {'key': key_info}
+        if certificates_req != 'none':
+            certs = [b64_der(cert)]
+            if certificates_req == 'chain':
+                certs.extend(
+                    b64_der(pki_arch.get_cert(ca_cert_lbl))
+                    for ca_cert_lbl in pki_arch.get_chain(cert_spec.label)
+                )
+            response['cert'] = {'certificates': certs}
+        response['authMode'] = 'implicit'
+        service_params = self.service_params
+        scal = "2" if service_params.hash_pinning_required else "1"
+        response['SCAL'] = scal
+        response['multisign'] = service_params.multisign
+        return web.json_response(response)
+
+    async def credentials_authorize(self, request: web.Request):
+        config = self.certomancer_config
+
+        params = await request.json()
+        try:
+            cred_id = str(params['credentialID'])
+            num_signatures = int(params['numSignatures'])
+        except (KeyError, ValueError):
+            raise web.HTTPBadRequest()
+
+        pki_arch, cert_spec = self._parse_credential_id(cred_id)
+        if not pki_arch.is_subject_key_available(cert_spec.label):
+            raise web.HTTPBadRequest()
+
+        hashes_list = params.get('hash', None)
+        if hashes_list is None:
+            if self.service_params.hash_pinning_required:
+                raise web.HTTPBadRequest()
+        else:
+            if len(hashes_list) != num_signatures:
+                raise web.HTTPBadRequest()
+            hashes_list = [base64.b64decode(x) for x in hashes_list]
+
+        auth_obj = CSCAuthorization(
+            credential_id=cred_id, num_signatures=num_signatures,
+            hashes=hashes_list
+        )
+        sad = auth_obj.derive_sad(self.service_params.sad_secret)
+        return web.json_response({'SAD': sad})
+
+    async def signatures_sign_hash(self, request: web.Request):
+        config = self.certomancer_config
+
+        params = await request.json()
+        try:
+            cred_id = str(params['credentialID'])
+            sad = params['SAD']
+        except KeyError:
+            raise web.HTTPBadRequest()
+
+        csc_auth_obj = CSCAuthorization.verify_sad(
+            sad, secret=self.service_params.sad_secret, credential_id=cred_id
+        )
+
+        pki_arch, cert_spec = self._parse_credential_id(cred_id)
+        try:
+            priv_key_info = pki_arch.key_set.get_private_key(
+                cert_spec.subject_key
+            )
+        except ConfigurationError as e:
+            raise web.HTTPBadRequest()
+
+        try:
+            hash_list = [base64.b64decode(x) for x in params['hash']]
+            sign_algo_id = algos.SignedDigestAlgorithmId(params['signAlgo'])
+        except (KeyError, ValueError):
+            raise web.HTTPBadRequest()
+
+        if csc_auth_obj.hashes is not None:
+            if not set(hash_list).issubset(csc_auth_obj.hashes):
+                raise web.HTTPBadRequest()
+        else:
+            if not len(hash_list) <= csc_auth_obj.num_signatures:
+                raise web.HTTPBadRequest()
+
+        sign_algo_params = params.get('signAlgoParams', None)
+        if sign_algo_params is not None:
+            if sign_algo_id.native != 'rsassa_pss':
+                raise web.HTTPNotImplemented()
+            try:
+                sign_algo_params = algos.RSASSAPSSParams.load(
+                    base64.b64decode(sign_algo_params)
+                )
+            except ValueError:
+                raise web.HTTPBadRequest()
+        try:
+            sign_algo = algos.SignedDigestAlgorithm({
+                'algorithm': sign_algo_id,
+                'parameters': sign_algo_params
+            })
+        except ValueError:
+            raise web.HTTPBadRequest()
+
+        hash_algo_oid = params.get('hashAlgo', None)
+        try:
+            hash_algo = sign_algo.hash_algo
+        except ValueError:
+            if hash_algo_oid is None:
+                raise web.HTTPBadRequest()
+            hash_algo = algos.DigestAlgorithmId(hash_algo_oid).native
+
+        def _sign_hash(x):
+            signed = generic_sign_prehashed(
+                priv_key_info, x, sign_algo,
+                digest_algorithm=hash_algo
+            )
+            return base64.b64encode(signed).decode('ascii')
+
+        result = list(map(_sign_hash, hash_list))
+        return web.json_response({'signatures': result})
+
+
+def generic_sign_prehashed(private_key: keys.PrivateKeyInfo,
+                           tbs_digest: bytes,
+                           sd_algo: algos.SignedDigestAlgorithm,
+                           digest_algorithm) -> bytes:
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import dsa, ec, padding, rsa
+    from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+
+    if private_key.algorithm == 'rsassa_pss':
+        # as usual, we need to pretend it's a normal RSA key
+        # for pyca_cryptography to be able to load it
+        private_key_copy = private_key.copy()
+        private_key_copy['private_key_algorithm'] = {'algorithm': 'rsa'}
+        priv_key_bytes = private_key_copy.dump()
+    else:
+        priv_key_bytes = private_key.dump()
+
+    priv_key = serialization.load_der_private_key(
+        priv_key_bytes, password=None
+    )
+    sig_algo = sd_algo.signature_algo
+    if sig_algo == 'rsassa_pkcs1v15':
+        padding: padding.AsymmetricPadding = padding.PKCS1v15()
+        hash_algo = getattr(hashes, digest_algorithm.upper())()
+        assert isinstance(priv_key, rsa.RSAPrivateKey)
+        return priv_key.sign(tbs_digest, padding, Prehashed(hash_algo))
+    elif sig_algo == 'rsassa_pss':
+        parameters = None
+        if private_key.algorithm == 'rsassa_pss':
+            key_params = \
+                private_key['private_key_algorithm']['parameters']
+            # if the key is parameterised, we must use those params
+            if key_params.native is not None:
+                parameters = key_params
+        if parameters is None:
+            parameters = sd_algo['parameters']
+
+        mga: algos.MaskGenAlgorithm = parameters['mask_gen_algorithm']
+        if not mga['algorithm'].native == 'mgf1':
+            raise NotImplementedError("Only MFG1 is supported")
+
+        mgf_md_name = mga['parameters']['algorithm'].native
+
+        salt_len: int = parameters['salt_length'].native
+
+        mgf_md = getattr(hashes, mgf_md_name.upper())()
+        pss_padding: padding.AsymmetricPadding = padding.PSS(
+            mgf=padding.MGF1(algorithm=mgf_md),
+            salt_length=salt_len
+        )
+        hash_algo = getattr(hashes, digest_algorithm.upper())()
+        assert isinstance(priv_key, rsa.RSAPrivateKey)
+        return priv_key.sign(tbs_digest, pss_padding, Prehashed(hash_algo))
+    elif sig_algo == 'dsa':
+        assert isinstance(priv_key, dsa.DSAPrivateKey)
+        hash_algo = getattr(hashes, digest_algorithm.upper())()
+        return priv_key.sign(tbs_digest, Prehashed(hash_algo))
+    elif sig_algo == 'ecdsa':
+        hash_algo = getattr(hashes, digest_algorithm.upper())()
+        assert isinstance(priv_key, ec.EllipticCurvePrivateKey)
+        return priv_key.sign(
+            tbs_digest, signature_algorithm=ec.ECDSA(Prehashed(hash_algo))
+        )
+    else:  # pragma: nocover
+        raise NotImplementedError(
+            f"The signature signature_algo {sig_algo} "
+            f"is unsupported"
+        )
+
+
+def run_from_file(cfg_path, port, require_hash_pinning=True):
+    cfg = registry.CertomancerConfig.from_file(cfg_path)
+    csc_app = CSCWithCertomancer(
+        cfg, service_params=DummyServiceParams(
+            hash_pinning_required=require_hash_pinning
+        )
+    )
+    csc_app.register_routes()
+    web.run_app(
+        csc_app.app, host='localhost', port=port,
+    )
+
+
+if __name__ == '__main__':
+    import sys
+    scal = int(sys.argv[3])
+    run_from_file(
+        sys.argv[1], port=int(sys.argv[2]), require_hash_pinning=scal >= 2
+    )

--- a/pyhanko_tests/test_csc.py
+++ b/pyhanko_tests/test_csc.py
@@ -1,0 +1,603 @@
+import asyncio
+import base64
+from datetime import datetime
+
+import aiohttp
+import pytest
+from aiohttp import web
+from asn1crypto import algos
+from certomancer.registry import CertLabel
+from freezegun import freeze_time
+
+from pyhanko.sign.general import SigningError, _validate_raw
+from pyhanko.sign.signers import csc_signer
+from pyhanko_tests.csc_utils.csc_dummy_client import CSCDummyClientAuthManager
+from pyhanko_tests.csc_utils.csc_dummy_server import (
+    CSCWithCertomancer,
+    DummyServiceParams,
+)
+from pyhanko_tests.samples import CERTOMANCER, TESTING_CA
+
+SIGNER_B64 = """
+MIIEMDCCAxigAwIBAgICEAEwDQYJKoZIhvcNAQELBQAwWTELMAkGA1UEBhMCQkUxFDASBgNVBAoM
+C0V4YW1wbGUgSW5jMRowGAYDVQQLDBFUZXN0aW5nIEF1dGhvcml0eTEYMBYGA1UEAwwPSW50ZXJt
+ZWRpYXRlIENBMCIYDzIwMjAwMTAxMDAwMDAwWhgPMjAyMjAxMDEwMDAwMDBaMHExCzAJBgNVBAYT
+AkJFMRQwEgYDVQQKDAtFeGFtcGxlIEluYzEaMBgGA1UECwwRVGVzdGluZyBBdXRob3JpdHkxDjAM
+BgNVBAMMBUFsaWNlMSAwHgYJKoZIhvcNAQkBFhFhbGljZUBleGFtcGxlLmNvbTCCASIwDQYJKoZI
+hvcNAQEBBQADggEPADCCAQoCggEBAOFzgm4eL34uvUYrX4akyEBi+sn0gCYo8UOthApfluxF4cca
+GhCHdjZa1PwRpV3bDGFQpUbhNu0juCBkYbRGxasQOn1CUDF7DCCjztNEd779WwRlA5dnqWMFU5Ij
+toavSYl+CA1Ase2edxq7UjEZr4kIm7ADlUVpdKxLItJFEP4QOjqv5sENuiGCKpMqb/JGmvnLxRev
+xDZQ8hIDV2s07krCog8hRChie39mDNmZ/RH/JbgME6mGY99bDAnhu8xH41iBo8GemEmmFesx8YPr
+MivcXHk3QNt2LsKCAGZlG51fsrtiC31732W0+dc09PoITS0NMvP8/38dQmod3ktJBusCAwEAAaOB
+5TCB4jAdBgNVHQ4EFgQUXsenutQKZ62drno9rRRqOLVzCrgwHwYDVR0jBBgwFoAU7796UYsupC5K
+XdLO52F4zmo2SU8wDgYDVR0PAQH/BAQDAgbAMEcGA1UdHwRAMD4wPKA6oDiGNmh0dHA6Ly9weWhh
+bmtvLnRlc3RzL3Rlc3RpbmctY2EvY3Jscy9pbnRlcm0vbGF0ZXN0LmNybDBHBggrBgEFBQcBAQQ7
+MDkwNwYIKwYBBQUHMAGGK2h0dHA6Ly9weWhhbmtvLnRlc3RzL3Rlc3RpbmctY2Evb2NzcC9pbnRl
+cm0wDQYJKoZIhvcNAQELBQADggEBACwIBhziVaZdlWg5S7PCjnL2yEeDnJWW3c1DXzKz8++mjDR0
+GNsMgy1+XxKBR7gqaIDCUIPvgWko6UNfvt74txy1eBI4KHfWG/J3R9S54MTm+jZc/ctR9ma2kqcp
+nz5p6HjfgdN/ejY3Fop+dZSvapbQumk27/3boKjzftXJP1VD6LSpINBDEX4kw9w4xZDpgZOcxB+s
+k36fJ/cT50B7dYFFfSfKWCU7cpOYtkwnytfOBc4PxodIjrv1Y5ZSELyC8mY+U3zTlDLdG364BMSV
+x4AzyPTjm252vITdbnsFZTPkpEz2gfQnh0Ee5jq+vkPfUyB0tgGju0yu9EgFIu2pzGY=
+"""
+
+INTERM_B64 = """
+MIID2TCCAsGgAwIBAgICEAEwDQYJKoZIhvcNAQELBQAwUTELMAkGA1UEBhMCQkUxFDASBgNVBAoM
+C0V4YW1wbGUgSW5jMRowGAYDVQQLDBFUZXN0aW5nIEF1dGhvcml0eTEQMA4GA1UEAwwHUm9vdCBD
+QTAiGA8yMDAwMDEwMTAwMDAwMFoYDzIxMDAwMTAxMDAwMDAwWjBZMQswCQYDVQQGEwJCRTEUMBIG
+A1UECgwLRXhhbXBsZSBJbmMxGjAYBgNVBAsMEVRlc3RpbmcgQXV0aG9yaXR5MRgwFgYDVQQDDA9J
+bnRlcm1lZGlhdGUgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDB6drP3ogV8UnY
+2YM0GREPUCCEe7FX905/Ocl2MjyPyh3/vaf542LGQWdC1mf3fNQsMu2dqaZTwUQrKJwIs07QV7r1
+now3rKUNG8YyGtdZfKyt6jgOsfaZ5KB54sUtWGy4LKT4cPq0vEWnm8lFo91kvJqVOjFXWpUSKwTP
+YJV+riBmKg25C+8D2L5oKdMzQxd8o9K0kAI0fDF1CPbqtCB/GIzwN2Cq20bX9dpzTbZOlvIundA4
+hLYBNcfXnigPLylc3x3YxypoBotQ5L9MxKceBgrv1SfgtEAqxeYgUZe/UQdEG7jRy0JIYFKS/EWv
+HcJ6jAX+v64hKeIAslO/67TbAgMBAAGjga4wgaswHQYDVR0OBBYEFO+/elGLLqQuSl3SzudheM5q
+NklPMB8GA1UdIwQYMBaAFPG0eZUCsrRfOXL9sI/CX69bmlC1MBIGA1UdEwEB/wQIMAYBAf8CAQAw
+DgYDVR0PAQH/BAQDAgGGMEUGA1UdHwQ+MDwwOqA4oDaGNGh0dHA6Ly9weWhhbmtvLnRlc3RzL3Rl
+c3RpbmctY2EvY3Jscy9yb290L2xhdGVzdC5jcmwwDQYJKoZIhvcNAQELBQADggEBAAx7qZLSOIk4
+B7w6ymmPF3cKrafdJg83NhWAJZHOie9E23hhOV0uOLoaab2m+TbpqUXXpeuxCC3t2duLueSceHUX
+Y+UhZGF4LdTojK5yVnyHynJVwbAAzRyO1hIjI9SFW+NMsFNwN6t50RAhTGY7jZvvv2y3mMwUHE2u
+lgsQNax0Tyoh6yOtb752IWm0Yj+cEMQ36cjxkcFZgYTiziuYkYJM8wL+kADG+HUsnfdYJWMM/lJ7
+YEkSIm0lhec3xR6siySnZI2whU3twY37WcnxwjkAczSdHZJpyzrSyjp8rCwk0zOF4HGQr3WuJhHo
+kS0gHz5+cFMDBZxeP5Oq5UFvFtU=
+"""
+
+
+def test_proc_cert_info_response():
+    cred_info = csc_signer._process_certificate_info_response({
+        'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+        'key': {
+            'algo': ['1.2.840.113549.1.1.11'],
+            'len': 2048,
+        },
+        'multisign': 10,
+        'authMode': 'implicit',
+        'SCAL': 2,
+    })
+    assert cred_info.max_batch_size == 10
+    assert cred_info.hash_pinning_required
+    assert 'sha256_rsa' in cred_info.supported_mechanisms
+    assert 'Alice' in cred_info.signing_cert.subject.human_friendly
+
+
+@pytest.mark.parametrize('response_data,err_msg', [
+    ({
+        'cert': {},
+        'key': {
+            'algo': ['1.2.840.113549.1.1.11'],
+            'len': 2048,
+        }, 'multisign': 10, 'authMode': 'implicit', 'SCAL': 2,
+    }, "Could not retrieve certificates from response"),
+    ({
+         'key': {
+             'algo': ['1.2.840.113549.1.1.11'],
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': 2,
+     }, "Could not retrieve certificates from response"),
+    ({
+         'cert': {'certificates': [SIGNER_B64.replace('M', 'Z')]},
+         'key': {
+             'algo': ['1.2.840.113549.1.1.11'],
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': 2,
+     }, "Could not decode certificates in response"),
+    ({
+         'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+         'key': {
+             'algo': '1.2.840.113549.1.1.11',
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': 2,
+     }, "Could not retrieve supported signing mechanisms"),
+    ({
+         'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+         'key': {
+             'algo': ['zzz1.2.840.113549.1.1.11'],
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': 2,
+     }, "Could not retrieve supported signing mechanisms"),
+    ({
+         'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+         'key': {
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': 2,
+     }, "Could not retrieve supported signing mechanisms"),
+    ({
+        'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+        'key': {
+            'algo': ['1.2.840.113549.1.1.11'],
+            'len': 2048,
+        },
+        'authMode': 'implicit',
+        'SCAL': 2,
+    }, "Could not retrieve max batch size"),
+    ({
+         'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+         'key': {
+             'algo': ['1.2.840.113549.1.1.11'],
+             'len': 2048,
+         },
+         'multisign': 'foobar',
+         'authMode': 'implicit',
+         'SCAL': 2,
+     }, "Could not retrieve max batch size"),
+    ({
+         'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+         'key': {
+             'algo': ['1.2.840.113549.1.1.11'],
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': 3,
+     }, "SCAL value must be"),
+    ({
+         'cert': {'certificates': [SIGNER_B64, INTERM_B64]},
+         'key': {
+             'algo': ['1.2.840.113549.1.1.11'],
+             'len': 2048,
+         },
+         'multisign': 10,
+         'authMode': 'implicit',
+         'SCAL': "zzz",
+     }, "SCAL value must be"),
+])
+def test_proc_cert_info_response_errors(response_data, err_msg):
+    with pytest.raises(SigningError, match=err_msg):
+        csc_signer._process_certificate_info_response(response_data)
+
+
+def test_format_csc_auth_request():
+    # any old auth manager will do
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_signer.CSCServiceSessionInfo(
+            'https://example.com', 'foobar'
+        ),
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset(),
+            max_batch_size=10,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+    result = auth_man.format_csc_auth_request(
+        pin='1234', otp='123456',
+        hash_b64s=[
+            'Sa6Tcy/PjWP+HM51lmSYLb1bIxYfAH26hWGGKtyW0GM=',
+            'Sa6Tcy/PjWP+HM51lmSYLb1bIxYfAH26hWGGKtyW0GM='
+        ],
+        description='baz', client_data='quux'
+    )
+    assert result == {
+        'credentialID': 'foobar',
+        'numSignatures': 2,
+        'hash': [
+            'Sa6Tcy/PjWP+HM51lmSYLb1bIxYfAH26hWGGKtyW0GM=',
+            'Sa6Tcy/PjWP+HM51lmSYLb1bIxYfAH26hWGGKtyW0GM='
+        ],
+        'PIN': '1234', 'OTP': '123456',
+        'description': 'baz',
+        'clientData': 'quux'
+    }
+
+
+@freeze_time('2021-11-01T00:00:00+00:00')
+def test_parse_csc_auth_response():
+    response_data = {'SAD': 'foobar', 'expiresIn': 300}
+
+    expires_at = datetime.fromisoformat('2021-11-01T00:05:00+00:00')
+
+    result = csc_signer.CSCAuthorizationManager\
+        .parse_csc_auth_response(response_data)
+    assert result == csc_signer.CSCAuthorizationInfo(
+        sad='foobar', expires_at=expires_at
+    )
+
+
+@freeze_time('2021-11-01T00:00:00+00:00')
+def test_parse_csc_auth_response_default_expiry():
+    response_data = {'SAD': 'foobar'}
+
+    expires_at = datetime.fromisoformat('2021-11-01T01:00:00+00:00')
+
+    result = csc_signer.CSCAuthorizationManager \
+        .parse_csc_auth_response(response_data)
+    assert result == csc_signer.CSCAuthorizationInfo(
+        sad='foobar', expires_at=expires_at
+    )
+
+
+@pytest.mark.parametrize('response_data,err_msg', [
+    ({}, "Could not extract SAD"),
+    ({'SAD': 'foobar', 'expiresIn': 'nonsense'}, "Could not process expiresIn"),
+])
+def test_parse_csc_auth_response_error(response_data, err_msg):
+    with pytest.raises(SigningError, match=err_msg):
+        csc_signer.CSCAuthorizationManager \
+            .parse_csc_auth_response(response_data)
+
+
+# network failure tests
+async def test_cert_provision_fail():
+    csc_session_info = csc_signer.CSCServiceSessionInfo(
+        'https://example.invalid', 'foobar'
+    )
+    with pytest.raises(SigningError, match='Credential info request failed'):
+        async with aiohttp.ClientSession() as session:
+            await csc_signer.fetch_certs_in_csc_credential(
+                 session, csc_session_info=csc_session_info
+            )
+
+
+async def test_sign_mechanism_not_supported():
+    csc_session_info = csc_signer.CSCServiceSessionInfo(
+        'https://example.com', 'foobar'
+    )
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_session_info,
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset({'is_nonsense'}),
+            max_batch_size=10,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+    # check expected failure for a signing attempt
+    with pytest.raises(SigningError, match='No signing results available'):
+        async with aiohttp.ClientSession() as session:
+            signer = csc_signer.CSCSigner(session, auth_manager=auth_man)
+            await signer.async_sign_raw(b'foobarbazquux', 'sha256')
+
+    # check expected failure when fetching the signature mechanism directly
+    with pytest.raises(SigningError, match='must be one of'):
+        # noinspection PyTypeChecker
+        signer = csc_signer.CSCSigner(None, auth_manager=auth_man)
+        signer.get_signature_mechanism(digest_algorithm='sha256')
+
+    # ...but overrides should still work
+    # noinspection PyTypeChecker
+    signer = csc_signer.CSCSigner(None, auth_manager=auth_man)
+    signer.signature_mechanism = mech \
+        = algos.SignedDigestAlgorithm({'algorithm': 'sha256_rsa'})
+    assert signer.get_signature_mechanism(digest_algorithm='sha256') == mech
+
+
+async def test_sign_network_fail():
+    csc_session_info = csc_signer.CSCServiceSessionInfo(
+        'https://example.invalid', 'foobar'
+    )
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_session_info,
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset({'sha256_rsa'}),
+            max_batch_size=10,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+
+    with pytest.raises(SigningError, match='No signing results available'):
+        async with aiohttp.ClientSession() as session:
+            signer = csc_signer.CSCSigner(session, auth_manager=auth_man)
+            await signer.async_sign_raw(b'foobarbazquux', 'sha256')
+
+
+async def test_sign_wrong_number_of_sigs(aiohttp_client):
+    csc_session_info = csc_signer.CSCServiceSessionInfo('', 'foobar')
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_session_info,
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset({'sha256_rsa'}),
+            max_batch_size=2,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+
+    async def fake_return(_request):
+        return web.json_response({
+            'signatures': [base64.b64encode(bytes(512)).decode('ascii'), ]
+        })
+    app = web.Application()
+    app.router.add_post('/csc/v1/signatures/signHash',  fake_return)
+    client = await aiohttp_client(app)
+    signer = csc_signer.CSCSigner(
+        client, auth_manager=auth_man, batch_size=2,
+        batch_autocommit=False
+    )
+    result = asyncio.gather(
+        signer.async_sign_raw(b'foobarbaz', 'sha256'),
+        signer.async_sign_raw(b'foobarbazquux', 'sha256'),
+    )
+
+    with pytest.raises(SigningError, match='Expected 2 signatures'):
+        await asyncio.sleep(1)
+        await signer.commit()
+    try:
+        result.cancel()
+        await result
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.parametrize('response_obj', [{'signatures': [None]}, {}])
+async def test_sign_unreadable_sig(aiohttp_client, response_obj):
+    csc_session_info = csc_signer.CSCServiceSessionInfo('', 'foobar')
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_session_info,
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset({'sha256_rsa'}),
+            max_batch_size=1,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+
+    async def fake_return(_request):
+        return web.json_response(response_obj)
+
+    app = web.Application()
+    app.router.add_post('/csc/v1/signatures/signHash',  fake_return)
+    client = await aiohttp_client(app)
+    signer = csc_signer.CSCSigner(
+        client, auth_manager=auth_man, batch_size=1,
+        batch_autocommit=False, client_data='Some client data, because why not'
+    )
+    result = asyncio.create_task(signer.async_sign_raw(b'foobarbaz', 'sha256'))
+    with pytest.raises(SigningError, match='Expected response with b64'):
+        await asyncio.sleep(1)
+        await signer.commit()
+
+    try:
+        result.cancel()
+        await result
+    except asyncio.CancelledError:
+        pass
+
+async def test_fail_different_digest():
+    csc_session_info = csc_signer.CSCServiceSessionInfo('', 'foobar')
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_session_info,
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset({'sha256_rsa'}),
+            max_batch_size=2,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+    # noinspection PyTypeChecker
+    signer = csc_signer.CSCSigner(None, auth_manager=auth_man, batch_size=2)
+    with pytest.raises(SigningError, match='same digest function'):
+        result = asyncio.gather(
+            signer.async_sign_raw(b'foobarbaz', 'sha256'),
+            signer.async_sign_raw(b'foobarbazquux', 'sha512'),
+        )
+        await result
+
+
+async def _set_up_dummy_client(aiohttp_client, require_hash_pinning=True):
+    csc_session_info = csc_signer.CSCServiceSessionInfo(
+        '', 'testing-ca/signer1'
+    )
+    csc_dummy = CSCWithCertomancer(
+        certomancer_config=CERTOMANCER,
+        service_params=DummyServiceParams(
+            hash_pinning_required=require_hash_pinning
+        )
+    )
+    csc_dummy.register_routes()
+    client = await aiohttp_client(csc_dummy.app)
+
+    auth_man = CSCDummyClientAuthManager(
+        client, session_info=csc_session_info,
+        credential_info=await csc_signer.fetch_certs_in_csc_credential(
+            client, csc_session_info
+        )
+    )
+    return client, auth_man, csc_dummy
+
+
+async def test_submit_job_during_commit(aiohttp_client):
+
+    client, auth_man, csc_dummy = await _set_up_dummy_client(aiohttp_client)
+
+    class SlowCommitter(csc_signer.CSCSigner):
+        _committed_once = False
+        async def _do_commit(self, batch):
+            # waste time
+            if not self._committed_once:
+                await asyncio.sleep(5)
+            self._committed_once = True
+            await super()._do_commit(batch)
+
+    signer = SlowCommitter(
+        session=client, auth_manager=auth_man,
+        batch_autocommit=True, batch_size=2
+    )
+
+    async def make_first_sig():
+        # submit an incomplete batch
+        result = asyncio.create_task(
+            signer.async_sign_raw(b'foobar1', 'sha256'),
+        )
+        await asyncio.sleep(1)
+        await signer.commit()
+        return await result
+
+    async def make_other_sigs():
+        await asyncio.sleep(2)
+        return await asyncio.gather(
+            signer.async_sign_raw(b'foobar2', 'sha256'),
+            signer.async_sign_raw(b'foobar3', 'sha256'),
+        )
+
+    sig1, others = await asyncio.gather(make_first_sig(), make_other_sigs())
+
+    signer_cert = TESTING_CA.get_cert(CertLabel('signer1'))
+    for ix, sig in enumerate([sig1, *others]):
+        _validate_raw(
+            sig, b'foobar%d' % (ix + 1), signer_cert,
+            signature_algorithm=algos.SignedDigestAlgorithm({
+                'algorithm': 'sha256_rsa'
+            }),
+            md_algorithm='sha256'
+        )
+    assert auth_man.authorizations_requested == 2
+
+
+async def test_multi_commit_failure(aiohttp_client):
+
+    client, auth_man, csc_dummy = await _set_up_dummy_client(aiohttp_client)
+    # deliberately pass a bogus SAD to make the commit fail
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=auth_man.csc_session_info,
+        credential_info=auth_man.credential_info,
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+
+    class SlowCommitter(csc_signer.CSCSigner):
+        async def _do_commit(self, batch):
+            # waste time
+            await asyncio.sleep(3)
+            await super()._do_commit(batch)
+
+    signer = SlowCommitter(
+        session=client, auth_manager=auth_man,
+        batch_autocommit=False, batch_size=1
+    )
+
+    async def produce_signature():
+        result = asyncio.create_task(
+            signer.async_sign_raw(b'foobar', 'sha256'),
+        )
+        await asyncio.sleep(1)
+        with pytest.raises(SigningError, match='Signature request failed'):
+            await signer.commit()
+        with pytest.raises(SigningError, match='No signing results'):
+            return await result
+
+    async def commit_again():
+        with pytest.raises(SigningError, match='Commit failed'):
+            await asyncio.sleep(2)
+            await signer.commit()
+    await asyncio.gather(produce_signature(), commit_again())
+    # this should now return immediately as there is no batch
+    await signer.commit()
+
+
+async def test_csc_with_parameters(aiohttp_client):
+    #  produce a signature with parameters
+
+    client, auth_man, csc_dummy = await _set_up_dummy_client(aiohttp_client)
+
+    signer = csc_signer.CSCSigner(
+        session=client, auth_manager=auth_man,
+        batch_autocommit=True, batch_size=1,
+        prefer_pss=True
+    )
+
+    result = await signer.async_sign_raw(b'foobar', digest_algorithm='sha256')
+    signer_cert = TESTING_CA.get_cert(CertLabel('signer1'))
+    mech = signer.get_signature_mechanism('sha256')
+    assert mech.signature_algo == 'rsassa_pss'
+    _validate_raw(
+        result, b'foobar', signer_cert,
+        signature_algorithm=mech, md_algorithm='sha256'
+    )
+
+
+async def test_prefetched_sad_not_twice(aiohttp_client):
+    client, auth_man, csc_dummy = await _set_up_dummy_client(
+        aiohttp_client, require_hash_pinning=False
+    )
+
+    # prefetch SAD that is not bound to any hashes
+    async with client.post('/csc/v1/credentials/authorize',
+                           json=auth_man.format_csc_auth_request(),
+                           raise_for_status=True) as resp:
+        sad = (await resp.json())['SAD']
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=auth_man.csc_session_info,
+        credential_info=auth_man.credential_info,
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad=sad)
+    )
+
+    signer = csc_signer.CSCSigner(
+        session=client, auth_manager=auth_man,
+        batch_autocommit=True, batch_size=1,
+    )
+
+    result = await signer.async_sign_raw(b'foobar', digest_algorithm='sha256')
+    signer_cert = TESTING_CA.get_cert(CertLabel('signer1'))
+    _validate_raw(
+        result, b'foobar', signer_cert,
+        signature_algorithm=algos.SignedDigestAlgorithm({
+            'algorithm': 'sha256_rsa'
+        }), md_algorithm='sha256'
+    )
+
+    # but a second attempt should fail
+    with pytest.raises(SigningError, match='No signing results'):
+        await signer.async_sign_raw(b'foobar', digest_algorithm='sha256')
+
+
+# The API docs say that the placeholder will be 512 bytes, so we record
+# that in a test here
+
+async def test_csc_placeholder_sig_size():
+
+    csc_session_info = csc_signer.CSCServiceSessionInfo(
+        'https://example.com', 'foobar'
+    )
+    auth_man = csc_signer.PrefetchedSADAuthorizationManager(
+        csc_session_info=csc_session_info,
+        credential_info=csc_signer.CSCCredentialInfo(
+            signing_cert=TESTING_CA.get_cert(CertLabel('signer1')),
+            chain=[], supported_mechanisms=frozenset({'is_nonsense'}),
+            max_batch_size=10,
+            hash_pinning_required=False, response_data={}
+        ),
+        csc_auth_info=csc_signer.CSCAuthorizationInfo(sad='')
+    )
+    # noinspection PyTypeChecker
+    signer = csc_signer.CSCSigner(None, auth_manager=auth_man)
+    await signer.async_sign_raw(b'foobarbazquux', 'sha256', dry_run=True)

--- a/pyhanko_tests/with_live_csc_dummy.py
+++ b/pyhanko_tests/with_live_csc_dummy.py
@@ -1,0 +1,94 @@
+import asyncio
+import logging
+import os
+
+import pytest
+
+from pyhanko.pdf_utils.reader import PdfFileReader
+from pyhanko_tests.csc_utils.csc_dummy_client import CSCDummy
+from pyhanko_tests.signing_commons import async_val_trusted
+
+logger = logging.getLogger(__name__)
+
+
+SKIP_LIVE = False
+CSC_SCAL2_HOST_URL = os.environ.get('LIVE_CSC_SCAL2_HOST_URL', None)
+if not CSC_SCAL2_HOST_URL:
+    logger.warning("Skipping live tests -- no CSC dummy host")
+    SKIP_LIVE = True
+
+CERTOMANCER_HOST_URL = os.environ.get('LIVE_CERTOMANCER_HOST_URL', None)
+if not CERTOMANCER_HOST_URL:
+    logger.warning("Skipping live tests -- no Certomancer host")
+    SKIP_LIVE = True
+
+TIMEOUT = 10
+
+run_if_live = pytest.mark.skipif(
+    SKIP_LIVE, reason="no CSC/Certomancer instance available"
+)
+
+
+@run_if_live
+async def test_simple_sign_with_dummy():
+    from io import BytesIO
+
+    from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+    from pyhanko.sign import PdfSignatureMetadata, async_sign_pdf
+    from pyhanko_tests.samples import MINIMAL_ONE_FIELD
+
+    w = IncrementalPdfFileWriter(BytesIO(MINIMAL_ONE_FIELD))
+
+    async with CSCDummy(endpoint_url=CSC_SCAL2_HOST_URL,
+                        credential_id='testing-ca/signer1-long',
+                        timeout=TIMEOUT) as signer:
+        out = await async_sign_pdf(
+            w, signature_meta=PdfSignatureMetadata(),
+            existing_fields_only=True, signer=signer, in_place=True
+        )
+
+    r = PdfFileReader(out)
+    emb = r.embedded_signatures[0]
+    await async_val_trusted(emb)
+
+
+@run_if_live
+@pytest.mark.parametrize(
+    'num_results,batch_size,expected_auth_count,waste_time', [
+        (3, 3, 1, 0),
+        (6, 3, 2, 0),
+        (6, 3, 2, 1)
+    ]
+)
+async def test_implicit_batch_sign_with_dummy(num_results, batch_size,
+                                              expected_auth_count, waste_time):
+    from io import BytesIO
+
+    from pyhanko.pdf_utils.incremental_writer import IncrementalPdfFileWriter
+    from pyhanko.sign import PdfSignatureMetadata, async_sign_pdf
+    from pyhanko_tests.samples import MINIMAL_ONE_FIELD
+
+    async with CSCDummy(endpoint_url=CSC_SCAL2_HOST_URL,
+                        credential_id='testing-ca/signer1-long',
+                        waste_time=waste_time,
+                        timeout=TIMEOUT, batch_size=batch_size) as signer:
+
+        async def do_sign(num):
+            w = IncrementalPdfFileWriter(BytesIO(MINIMAL_ONE_FIELD))
+            return await async_sign_pdf(
+                w, signature_meta=PdfSignatureMetadata(
+                    reason=f"I'm number #{num}!"
+                ),
+                existing_fields_only=True, signer=signer, in_place=True,
+            )
+        results = await asyncio.gather(
+            *(do_sign(i) for i in range(1, num_results + 1))
+        )
+        assert signer.auth_manager.authorizations_requested \
+               == expected_auth_count
+
+    for ix, out in enumerate(results):
+        r = PdfFileReader(out)
+        emb = r.embedded_signatures[0]
+        assert emb.sig_object['/Reason'].endswith(f"#{ix + 1}!")
+        await async_val_trusted(emb)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ uharfbuzz==0.16.1
 isort>=5.9.3
 aiohttp~=3.8.0
 pytest-aiohttp~=0.3.0
+python-pae==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,8 @@ setup(
     tests_require=[
         'pytest>=6.1.1', 'requests-mock>=1.8.0',
         'freezegun>=1.1.0', 'certomancer~=0.6.0',
-        'aiohttp>=3.7.4', 'pytest-aiohttp~=0.3.0'
+        'aiohttp~=3.8.0', 'pytest-aiohttp~=0.3.0',
+        'python-pae==0.1.0'
     ],
     keywords="signature pdf pades digital-signature pkcs11"
 )


### PR DESCRIPTION
Since the discussion in #29 seems to have stalled a little, and the new asynchronous nature of the internal API (since `0.9.0`) open up quite a few new options, I decided to have another go at CSC integration myself.

However, the approach I took markedly differs from the one in #29 in a number of ways. The code in #29 focuses on providing a convenience layer on top of pyHanko's interrupted signing API by providing serialisation helpers. On the other hand, it leaves the CSC-specific calls in the API user's hands.

This PR takes advantage of the new asynchronous internals to directly provide the CSC protocol logic in a `Signer` implementation. It's written to be very generalist (the idea is to support both batch signing and "one-shot" signing), but I've only tested it against one specific implementation so far (more on that later).
Note that this was impossible to do efficiently back when the code in #29 was written, since the CSC calls in a `Signer` subclass would have to block for unacceptably long times prior to `0.9.0`.
Of course, the `CSCSigner` implementation in this PR can still be used in an interrupted signing workflow all the same (in much the same way as the docstring comments in #29 suggest), but this one slots into pyHanko's higher-level APIs as well.
In a way, this is analogous to the way `PKCS11Signer` works right now.

The only things that the API caller _has_ to take care of themselves are the authentication & authorization parts. This includes getting an OAuth token and performing the `credentials/authorize` call, since the implementation-dependent aspects are significant there.
For `credentials/authorize`, the caller has to subclass the abstract `CSCAuthorizationManager` class and pass an instance to the `CSCSigner` at init time. The authorization function on `CSCAuthorizationManager` will be invoked (asynchronously) when required.

-----------

So, what's next? This PR is far from being ready for merging, here's a (possibly non-exhaustive) list of things that need to happen first:

 - Given my relatively limited experience with the CSC protocol, I'd like to solicit some input: not just about implementation errors/misconceptions on my part, but also in regards to "implementation realities" in existing CSC service providers (read: noncompliant implementations) that exist out there in the wild.
 - I ran my initial tests against the CSC sandbox on ssl.com. If anyone knows of any other CSC vendors that supply a sandbox to experiment with: please let me know!
 - I'm going to implement a CSC dummy server on top of [Certomancer](https://github.com/MatthiasValvekens/certomancer) and use that to write a bunch of integration tests.
 - I still need to test the batch signing functionality (both in the high-level API and with low-level "interrupted signing" workflows à la #29).
 - Document the new API properly.

I intentionally _didn't_ try to resolve the serialisation issue that arose in the discussion on #29 here, since it's orthogonal to what this PR is trying to achieve. I'm open to having that conversation, though (but perhaps it's better to take it to the discussion forum).

Thoughts?

