### PR TITLE
Bugfix/post signing credentials

### DIFF
--- a/pyhanko/pdf_utils/reader.py
+++ b/pyhanko/pdf_utils/reader.py
@@ -18,6 +18,7 @@ from typing import Optional, Set, Tuple, Union
 
 from . import generic, misc
 from .crypt import (
+    AuthResult,
     EnvelopeKeyDecrypter,
     PubKeySecurityHandler,
     SecurityHandler,
@@ -444,7 +445,7 @@ class PdfFileReader(PdfHandler):
         self.has_xref_stream = xref_builder.has_xref_stream
         return xref_cache, xref_builder.trailer
 
-    def decrypt(self, password: Union[str, bytes]):
+    def decrypt(self, password: Union[str, bytes]) -> AuthResult:
         """
         When using an encrypted PDF file with the standard PDF encryption
         handler, this function will allow the file to be decrypted.
@@ -481,7 +482,7 @@ class PdfFileReader(PdfHandler):
 
         return sh.authenticate(password, id1=self.document_id[0])
 
-    def decrypt_pubkey(self, credential: EnvelopeKeyDecrypter):
+    def decrypt_pubkey(self, credential: EnvelopeKeyDecrypter) -> AuthResult:
         """
         Decrypt a PDF file encrypted using public-key encryption by providing
         a credential representing the private key of one of the recipients.


### PR DESCRIPTION
## Description of the changes

Fix for issue #91, by introducing (internal) serialisation & deserialisation mechanisms for file access credentials.

## Checklist

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.


## Additional comments

There's some outstanding work to be done regarding documenting the new internal credential API, and some efficiency improvements for cases where the serialisation step doesn't make sense. These have been flagged in situ.
