### PR TITLE
Support certificates with no CN in the Subject

### DIFF
--- a/pyhanko/sign/signers/pdf_cms.py
+++ b/pyhanko/sign/signers/pdf_cms.py
@@ -356,7 +356,10 @@ class Signer:
             :attr:`signing_cert`.
         """
         name: x509.Name = self.signing_cert.subject
-        result = name.native['common_name']
+        try:
+            result = name.native['common_name']
+        except KeyError:
+            result = name.native['organization_name']
         try:
             email = name.native['email_address']
             result = '%s <%s>' % (result, email)

--- a/pyhanko_tests/data/crypto/certomancer.yml
+++ b/pyhanko_tests/data/crypto/certomancer.yml
@@ -110,6 +110,8 @@ pki-architectures:
         email-address: bob@example.com
       invalid-cn:
         common-name: "Invalidא"
+      signer-no-cn:
+        email-address: info@example.com
     certs:
       root:
         subject: root
@@ -243,6 +245,10 @@ pki-architectures:
         revocation:
           revoked-since: "2020-12-01T00:00:00+0000"
           reason: key_compromise
+      signer-no-cn:
+        subject: signer-no-cn
+        subject-key: signer1
+        template: signer1
       signer1-long:
         subject: signer1
         template: signer1


### PR DESCRIPTION
## Description of the changes

Support certificates with no Common Name (CN) in the Subject.


## Caveats

Assumes a Organisation Name exists in the certificate's Subject.


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

