### PR TITLE
Make `signing_cert` optional for most of the signing process

### DIFF
--- a/docs/lib-guide/signing.rst
+++ b/docs/lib-guide/signing.rst
@@ -745,6 +745,13 @@ Interrupted signing
     The new async-first API requires some changes to the workflow at this (relatively low)
     level of abstraction.
 
+.. versionchanged:: 0.14.0
+    It is no longer mandatory to make the signer's certificate available from the start of the workflow,
+    although this comes at the cost of some convenience (signature size estimation and revocation info
+    collection being two major ones). This makes it easier to implement remote signing scenarios where
+    the signer's certificate is unknown until the remote signing service produces its response.
+
+
 There are use cases where trying to run the entire signing process in one go isn't feasible.
 Think of a remote signing scenario with pyHanko running on a server, and calling an external signing
 service to perform the cryptographic operations, or a case where pyHanko needs to wait for

--- a/pyhanko/sign/signers/cms_embedder.py
+++ b/pyhanko/sign/signers/cms_embedder.py
@@ -219,12 +219,12 @@ class SigAppearanceSetup:
     Timestamp to show in the signature appearance.
     """
 
-    name: str
+    name: Optional[str]
     """
     Signer name to show in the signature appearance.
     """
 
-    text_params: dict = None
+    text_params: Optional[dict] = None
     """
     Additional text interpolation parameters to pass to the underlying
     stamp style.
@@ -262,11 +262,11 @@ class SigAppearanceSetup:
 
         name = self.name
         timestamp = self.timestamp
-        extra_text_params = self.text_params or {}
-        text_params = {
-            'signer': name,
-            **extra_text_params
-        }
+        text_params = {}
+        if name is not None:
+            text_params['signer'] = name
+        text_params.update(self.text_params or {})
+
         if isinstance(style, TextStampStyle):
             text_params['ts'] = timestamp.strftime(style.timestamp_format)
 

--- a/pyhanko/sign/signers/pdf_cms.py
+++ b/pyhanko/sign/signers/pdf_cms.py
@@ -1413,9 +1413,23 @@ class ExternalSigner(Signer):
     It embeds a fixed signature value into the CMS, set at initialisation.
 
     Intended for use with :ref:`interrupted-signing`.
+
+    :param signing_cert:
+        The signer's certificate.
+    :param cert_registry:
+        The certificate registry to use in CMS generation.
+    :param signature_value:
+        The value of the signature as a byte string, a placeholder length,
+        or ``None``.
+    :param signature_mechanism:
+        The signature mechanism used by the external signing service.
+    :param prefer_pss:
+        Switch to prefer PSS when producing RSA signatures, as opposed to
+        RSA with PKCS#1 v1.5 padding.
+    :param embed_roots:
+        Whether to embed relevant root certificates into the CMS payload.
     """
 
-    # TODO document parameters
     def __init__(self, signing_cert: Optional[x509.Certificate],
                  cert_registry: Optional[CertificateStore],
                  signature_value: Union[bytes, int, None] = None,

--- a/pyhanko/sign/signers/pdf_signer.py
+++ b/pyhanko/sign/signers/pdf_signer.py
@@ -1442,11 +1442,17 @@ class PdfSigningSession:
         validation_context = signature_meta.validation_context
 
         if signature_meta.embed_validation_info:
-            if validation_context is None:
+            if self.pdf_signer.signer.signing_cert is None:
                 raise SigningError(
-                    'A validation context must be provided if '
-                    'validation/revocation info is to be embedded into the '
-                    'signature.'
+                    "A signer's certificate must be provided if "
+                    "validation/revocation info is to be embedded into the "
+                    "signature."
+                )
+            elif validation_context is None:
+                raise SigningError(
+                    "A validation context must be provided if "
+                    "validation/revocation info is to be embedded into the "
+                    "signature."
                 )
             elif not validation_context.fetching_allowed:
                 logger.warning(
@@ -1690,6 +1696,11 @@ class PdfSigningSession:
         flags: SigSeedValFlags = sv_spec.flags
 
         if sv_spec.cert is not None:
+            if pdf_signer.signer.signing_cert is None:
+                raise SigningError(
+                    "Cannot verify seed value constraints on the signer's "
+                    "certificate since it is not available"
+                )
             sv_spec.cert.satisfied_by(
                 pdf_signer.signer.signing_cert, validation_path
             )


### PR DESCRIPTION
## Description of the changes

This is an internal plumbing change that makes the signature preparation process less reliant on the `signing_cert` attribute in the `Signer` hierarchy. In other words, provided you're willing to go without some conveniences, you can now prepare documents for signing without having access to the signer's certificate ahead of time. This is mostly relevant for the [interrupted signing workflow](https://pyhanko.readthedocs.io/en/latest/lib-guide/signing.html#interrupted-signing), more specifically in scenarios involving remote signing services that supply CMS objects containing short-lived certificates that are generated on-the-fly after the request is submitted.

This has come up often in the past, with issues going back as far as #3,  but also #31, #90 and #103.


## Caveats

Some of the things that pyHanko usually does automatically will no longer work in the absence of a signer's certificate. These include the following:

 - default digest algorithm selection,
 - signature container size estimation,
 - certificate constraint enforcement,
 - pre-signing revocation information collection.

Also note that, in practice, you still need a signer's certificate to assemble a working CMS `SignedData` container. As such, built-in signers like `SimpleSigner` and `PKCS11Signer` will keep the `signing_cert` requirement. `ExternalSigner`, which is largely a dummy implementation for use with the interrupted signing workflow, does accept `None` for the signer's certificate.


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.

