### PR TITLE
Improve PKCS#11 token selection

### DIFF
--- a/docs/cli-guide/config.rst
+++ b/docs/cli-guide/config.rst
@@ -200,7 +200,8 @@ want to put the parameters in the configuration file. You can declare named PKCS
     pkcs11-setups:
         test-setup:
             module-path: /usr/lib/libsofthsm2.so
-            token-label: testrsa
+            token-criteria:
+                label: testrsa
             cert-label: signer
 
 If you need to, you can also put the user PIN right in the configuration:
@@ -210,7 +211,8 @@ If you need to, you can also put the user PIN right in the configuration:
     pkcs11-setups:
         test-setup:
             module-path: /usr/lib/libsofthsm2.so
-            token-label: testrsa
+            token-criteria:
+                label: testrsa
             cert-label: signer
             user-pin: 1234
 
@@ -223,6 +225,25 @@ To use a named PKCS#11 configuration from the command line, invoke pyHanko like 
 .. code-block:: bash
 
     pyhanko sign addsig pkcs11 --p11-setup test-setup input.pdf output.pdf
+
+
+Named PKCS#11 setups also allow you to access certain advanced features that otherwise aren't
+available from the CLI directly. Here is an example.
+
+.. code-block:: yaml
+
+   pkcs11-setups:
+      test-setup:
+          module-path: /path/to/module.so
+          token-criteria:
+              serial: 17aa21784b9f
+          cert-id: 1382391af78ac390
+          key-id: 1382391af78ac390
+
+
+This configuration will select a token based on the serial number instead of the label,
+and use PKCS#11 object IDs to select the certificate and the private key. All of these
+are represented as hex strings.
 
 For a full overview of the parameters you can set on a PKCS#11 configuration, see the API reference
 documentation for :class:`~pyhanko.config.PKCS11SignatureConfig`.

--- a/docs/cli-guide/signing.rst
+++ b/docs/cli-guide/signing.rst
@@ -222,13 +222,16 @@ In order to do so, you'll need the following information:
  - The path to the PKCS#11 module, which is typically a shared object library (``.so``, ``.dll``
    or ``.dylib``, depending on your operating system)
 
- - The label of the PKCS#11 token you're accessing.
+ - The label of the PKCS#11 token you're accessing (unless the token selection criteria
+   are specified in the configuration file).
 
  - The PKCS#11 label(s) of the certificate and key you're using, stored in the token.
    If the key and certificate labels are the same, you can omit the key label.
 
 Most of these settings can be stored in the configuration file as well, see
-:ref:`pkcs11-setup-conf`.
+:ref:`pkcs11-setup-conf`. In fact, there are quite a few advanced settings that are not exposed
+as command-line switches, but can be specified in the configuration file.
+These include selecting tokens by serial number and selecting keys and certificates by ID.
 
 With this information, producing a basic signature isn't very hard:
 

--- a/pyhanko/cli.py
+++ b/pyhanko/cli.py
@@ -22,6 +22,7 @@ from pyhanko.config import (
     PKCS11SignatureConfig,
     PKCS12SignatureConfig,
     StdLogOutput,
+    TokenCriteria,
     init_validation_context_kwargs,
     parse_cli_config,
     parse_logging_config,
@@ -1168,7 +1169,7 @@ def addsig_pkcs11(ctx, infile, outfile, lib, token_label,
 
         pkcs11_config = PKCS11SignatureConfig(
             module_path=lib, cert_label=cert_label, key_label=key_label,
-            slot_no=slot_no, token_label=token_label,
+            slot_no=slot_no, token_criteria=TokenCriteria(token_label),
             # for now, DEFER requires a config file
             prompt_pin=pinentry_mode,
             raw_mechanism=raw_mechanism

--- a/pyhanko/pdf_utils/config_utils.py
+++ b/pyhanko/pdf_utils/config_utils.py
@@ -157,9 +157,9 @@ class ConfigurableMixin:
             key.replace('-', '_'): v for key, v in config_dict.items()
         }
 
-        cls._process_configurable_fields(config_dict)
-
         cls.process_entries(config_dict)
+
+        cls._process_configurable_fields(config_dict)
 
         enforce_required_keys(
             cls.__name__, {


### PR DESCRIPTION
## Description of the changes

This PR resolves #149. All other aspects of #149 turned out to have been implemented already.


Summary of the functional changes:
    
   - Deprecate usages of `token_label` in API and in config.
   - Favour more general `token_criteria` (also allows `serial` as a filter, and is more amenable to future extension)
   - Adjust config handling logic accordingly, with fallbacks for legacy data.

Internals/maintenance:

   - Made some tweaks to the config processing utilities to make parsing legacy config with fallbacks a bit more straightforward.
   - Add tests for both the new stuff and the legacy parts.
   - Documentation.


## Caveats

For CLI users, these changes are config-level only. We don't necessarily want every config option to correspond to a CLI flag, especially not for advanced features.


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.


### For documentation contributions (delete if not applicable)

 - [x] I have built the HTML documentation locally, and verified that the changes behave correctly in-browser.


