### PR TITLE
Fix potential division by 0 in stamp layout code

### DIFF
--- a/pyhanko/pdf_utils/layout.py
+++ b/pyhanko/pdf_utils/layout.py
@@ -516,8 +516,10 @@ class SimpleBoxLayoutRule(ConfigurableMixin):
             eff_width = margins.effective_width(container_box.width)
             eff_height = margins.effective_height(container_box.height)
 
-            x_scale = eff_width / inner_nat_width
-            y_scale = eff_height / inner_nat_height
+            x_scale = (eff_width / inner_nat_width) \
+                if inner_nat_width != 0 else 1
+            y_scale = (eff_height / inner_nat_height) \
+                if inner_nat_height != 0 else 1
             if scaling == InnerScaling.STRETCH_TO_FIT:
                 x_scale = y_scale = min(x_scale, y_scale)
             elif scaling == InnerScaling.SHRINK_TO_FIT:


### PR DESCRIPTION
## Description of the changes

Fixes #170, where a division by zero would occur when rendering a text stamp with natural width zero.


## Checklist

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.
