### PR TITLE
added application name for advanced signature properties

### DIFF
--- a/pyhanko/cli.py
+++ b/pyhanko/cli.py
@@ -37,6 +37,7 @@ from pyhanko.pdf_utils.writer import copy_into_new_writer
 from pyhanko.sign import fields, signers, validation
 from pyhanko.sign.general import SigningError, load_certs_from_pemder
 from pyhanko.sign.signers import DEFAULT_SIGNER_KEY_USAGE
+from pyhanko.sign.signers.pdf_byterange import BuildProps
 from pyhanko.sign.signers.pdf_cms import PdfCMSSignedAttributes
 from pyhanko.sign.timestamps import HTTPTimeStamper
 from pyhanko.sign.validation import RevocationInfoValidationType
@@ -804,7 +805,11 @@ def addsig(ctx, field, name, reason, location, certify, existing_only,
         certify=certify, subfilter=subfilter,
         embed_validation_info=with_validation_info,
         validation_context=vc, signer_key_usage=key_usage,
-        use_pades_lta=use_pades_lta
+        use_pades_lta=use_pades_lta,
+        app_build_props=BuildProps(
+            name='pyHanko CLI',
+            revision=__version__
+        )
     )
     ctx.obj[Ctx.NEW_FIELD_SPEC] = new_field_spec
     ctx.obj[Ctx.STAMP_STYLE] = _select_style(ctx, style_name, stamp_url)

--- a/pyhanko/sign/signers/pdf_signer.py
+++ b/pyhanko/sign/signers/pdf_signer.py
@@ -53,6 +53,7 @@ from .cms_embedder import (
     SigObjSetup,
 )
 from .pdf_byterange import (
+    BuildProps,
     DocumentTimestamp,
     PreparedByteRangeDigest,
     SignatureObject,
@@ -293,6 +294,14 @@ class PdfSignatureMetadata:
     signing is delegated to a trusted third party).
     """
 
+    app_build_props: Optional[BuildProps] = None
+    """
+    Properties of the application that created the signature.
+    
+    If specified, this data will be recorded in the **Prop_Build**
+    dictionary of the signature.
+    """
+    
     certify: bool = False
     """
     Sign with an author (certification) signature, as opposed to an approval
@@ -1964,6 +1973,7 @@ class PdfSigningSession:
             timestamp=system_time,
             name=name_specified if name_specified else None,
             location=signature_meta.location, reason=signature_meta.reason,
+            app_build_props=signature_meta.app_build_props,
         )
 
         # Pass in the SignatureObject settings


### PR DESCRIPTION
This fix is for issue #192. For the advanced signature property, I added a code to view the name of the application in PDF viewer and it required a small change in your code. 