### PR TITLE
Refine algorithm policy handling

### DIFF
--- a/pyhanko/sign/general.py
+++ b/pyhanko/sign/general.py
@@ -65,6 +65,7 @@ class ValueErrorWithMessage(ValueError):
 
     def __init__(self, failure_message):
         self.failure_message = str(failure_message)
+        super().__init__(failure_message)
 
 
 class CMSStructuralError(ValueErrorWithMessage):

--- a/pyhanko/sign/validation/ades.py
+++ b/pyhanko/sign/validation/ades.py
@@ -99,6 +99,7 @@ from .policy_decl import (
     SignatureValidationSpec,
     bootstrap_validation_data_handlers,
 )
+from .utils import CMSAlgorithmUsagePolicy
 
 __all__ = [
     'ades_basic_validation',
@@ -549,6 +550,7 @@ async def ades_basic_validation(
         signature_not_before_time=signature_not_before_time,
         extra_status_kwargs=extra_status_kwargs,
         status_cls=status_cls,
+        algorithm_policy=validation_spec.signature_algorithm_policy,
     )
     if isinstance(interm_result, AdESBasicValidationResult):
         return interm_result
@@ -571,6 +573,7 @@ async def _ades_basic_validation(
     raw_digest: Optional[bytes],
     signature_not_before_time: Optional[datetime],
     extra_status_kwargs: Optional[Dict[str, Any]],
+    algorithm_policy: Optional[CMSAlgorithmUsagePolicy],
     status_cls: Type[StatusType],
 ) -> Union[AdESBasicValidationResult, _InternalBasicValidationResult]:
     status_kwargs = dict(extra_status_kwargs or {})
@@ -580,6 +583,7 @@ async def _ades_basic_validation(
             raw_digest=raw_digest,
             validation_context=validation_context,
             key_usage_settings=key_usage_settings,
+            algorithm_policy=algorithm_policy,
         )
         status_kwargs.update(status_kwargs_from_validation)
     except errors.SignatureValidationError as e:
@@ -724,6 +728,7 @@ async def ades_with_time_validation(
         signature_not_before_time=signature_not_before_time,
         extra_status_kwargs=extra_status_kwargs,
         status_cls=status_cls,
+        algorithm_policy=validation_spec.signature_algorithm_policy,
     )
     if isinstance(interm_result, AdESBasicValidationResult):
         return AdESWithTimeValidationResult(

--- a/pyhanko/sign/validation/pdf_embedded.py
+++ b/pyhanko/sign/validation/pdf_embedded.py
@@ -54,6 +54,7 @@ from .status import (
     PdfSignatureStatus,
     SignatureCoverageLevel,
 )
+from .utils import CMSAlgorithmUsagePolicy
 
 __all__ = [
     'EmbeddedPdfSignature',
@@ -64,6 +65,7 @@ __all__ = [
     'report_seed_value_validation',
     'extract_contents',
 ]
+
 
 logger = logging.getLogger(__name__)
 
@@ -816,6 +818,7 @@ async def async_validate_pdf_signature(
     diff_policy: Optional[DiffPolicy] = None,
     key_usage_settings: Optional[KeyUsageConstraints] = None,
     skip_diff: bool = False,
+    algorithm_policy: Optional[CMSAlgorithmUsagePolicy] = None,
 ) -> PdfSignatureStatus:
     """
     .. versionadded:: 0.9.0
@@ -850,6 +853,16 @@ async def async_validate_pdf_signature(
         must or must not be present in the signer's certificate.
     :param skip_diff:
         If ``True``, skip the difference analysis step entirely.
+    :param algorithm_policy:
+        The algorithm usage policy for the signature validation.
+
+        .. warning::
+            This is distinct from the algorithm usage policy used for
+            certificate validation, but the latter will be used as a fallback
+            if this parameter is not specified.
+
+            It is nonetheless recommended to align both policies unless
+            there is a clear reason to do otherwise.
     :return:
         The status of the PDF signature in question.
     """
@@ -895,6 +908,7 @@ async def async_validate_pdf_signature(
         validation_context=signer_validation_context,
         status_kwargs=status_kwargs,
         key_usage_settings=key_usage_settings,
+        algorithm_policy=algorithm_policy,
     )
     tst_validity = status_kwargs.get('timestamp_validity', None)
     timestamp_found = (

--- a/pyhanko/sign/validation/policy_decl.py
+++ b/pyhanko/sign/validation/policy_decl.py
@@ -1,4 +1,3 @@
-import dataclasses
 import enum
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -22,6 +21,7 @@ from pyhanko_certvalidator.revinfo.archival import CRLContainer, OCSPContainer
 
 from pyhanko.sign.diff_analysis import DEFAULT_DIFF_POLICY, DiffPolicy
 from pyhanko.sign.validation import KeyUsageConstraints
+from pyhanko.sign.validation.utils import CMSAlgorithmUsagePolicy
 
 __all__ = [
     'SignatureValidationSpec',
@@ -30,6 +30,7 @@ __all__ = [
     'LocalKnowledge',
     'RevocationInfoGatheringSpec',
     'KnownPOE',
+    'CMSAlgorithmUsagePolicy',
     'bootstrap_validation_data_handlers',
 ]
 
@@ -92,6 +93,7 @@ class SignatureValidationSpec:
     ac_validation_policy: Optional[CertValidationPolicySpec] = None
     local_knowledge: LocalKnowledge = LocalKnowledge()
     key_usage_settings: KeyUsageConstraints = KeyUsageConstraints()
+    signature_algorithm_policy: Optional[CMSAlgorithmUsagePolicy] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Description of the changes

- Introduce a subclass `CMSAlgorithmUsagePolicy` of `AlgorithmUsagePolicy` for use
   with CMS validation specifically
 - Use that subclass to put in a hook to allow incongruent digest
   algorithms (fixes #242)


## Caveats

There is some minor API incompatibility, but only in internal APIs.


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.
