### PR TITLE
Fix various result propagation issues in AdES engine

### DIFF
--- a/.github/workflows/live-integration-tests.yml
+++ b/.github/workflows/live-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
           pip install 'certomancer[web-api,pkcs12]~=0.9.0' 'pytest>=6.1.1' 'aiohttp>=3.7.4' \
               'pytest-aiohttp~=1.0.4' dist/*.whl \
                requests-mock~=1.8.0 freezegun~=1.1.0 certomancer-csc-dummy==0.2.1 \
-               pyhanko-certvalidator==0.20.*
+               pyhanko-certvalidator==0.21.*
       - name: Install pyhanko-certvalidator dev build (feature branches only)
         if: ${{ startsWith(github.ref, 'refs/heads/feature') }}
         run: |

--- a/pyhanko/sign/validation/ades.py
+++ b/pyhanko/sign/validation/ades.py
@@ -822,6 +822,20 @@ async def ades_with_time_validation(
                 best_signature_time=signature_poe_time,
                 signature_not_before_time=signature_not_before_time,
             )
+    elif (
+        interm_result.ades_subindic
+        == AdESIndeterminate.CRYPTO_CONSTRAINTS_FAILURE_NO_POE
+    ):
+        # in this case error_time_horizon is set to the point where the
+        # constraint was triggered
+        if signature_poe_time >= temp_status.error_time_horizon:
+            return AdESWithTimeValidationResult(
+                ades_subindic=interm_result.ades_subindic,
+                api_status=temp_status,
+                failure_msg=None,
+                best_signature_time=signature_poe_time,
+                signature_not_before_time=signature_not_before_time,
+            )
 
     # TODO TSTInfo ordering/comparison check
     if (

--- a/pyhanko/sign/validation/ades.py
+++ b/pyhanko/sign/validation/ades.py
@@ -1008,6 +1008,9 @@ async def _ades_past_signature_validation(
     try:
         cert_info = extract_certificate_info(signed_data)
         cert = cert_info.signer_cert
+        validation_data_handlers.cert_registry.register_multiple(
+            cert_info.other_certs
+        )
     except CMSExtractionError:
         raise errors.SignatureValidationError(
             'signer certificate not included in signature',

--- a/pyhanko/sign/validation/status.py
+++ b/pyhanko/sign/validation/status.py
@@ -118,7 +118,7 @@ class SignatureStatus:
     Message digest algorithm used.
     """
 
-    validation_path: ValidationPath
+    validation_path: Optional[ValidationPath]
     """
     Validation path providing a valid chain of trust from the signer's
     certificate to a trusted root certificate.
@@ -170,7 +170,12 @@ class SignatureStatus:
         Reports whether the signer's certificate is trusted w.r.t. the currently
         relevant validation context and key usage requirements.
         """
-        return self.valid and self.intact and self.trust_problem_indic is None
+        return (
+            self.valid
+            and self.intact
+            and self.trust_problem_indic is None
+            and self.validation_path is not None
+        )
 
     # TODO explain in more detail.
     def summary(self, delimiter=',') -> str:
@@ -705,6 +710,15 @@ class ModificationInfo:
       by the difference policy will be stored in this attribute.
     """
 
+    docmdp_ok: Optional[bool] = None
+    """
+    Indicates whether the signature's
+    :attr:`~.ModificationInfo.modification_level` is in line with the document
+    signature policy in force.
+
+    If ``None``, compliance could not be determined.
+    """
+
     @property
     def modification_level(self) -> Optional[ModificationLevel]:
         """
@@ -734,15 +748,6 @@ class ModificationInfo:
 @dataclass(frozen=True)
 class PdfSignatureStatus(ModificationInfo, StandardCMSSignatureStatus):
     """Class to indicate the validation status of a PDF signature."""
-
-    docmdp_ok: Optional[bool] = None
-    """
-    Indicates whether the signature's
-    :attr:`~.ModificationInfo.modification_level` is in line with the document
-    signature policy in force.
-
-    If ``None``, compliance could not be determined.
-    """
 
     has_seed_values: bool = False
     """

--- a/pyhanko/sign/validation/status.py
+++ b/pyhanko/sign/validation/status.py
@@ -134,6 +134,15 @@ class SignatureStatus:
     in the chain) was revoked.
     """
 
+    error_time_horizon: Optional[datetime]
+    """
+    Informational timestamp indicating a point in time where the validation
+    behaviour potentially changed (e.g. expiration, revocation, etc.).
+
+    The presence of this value by itself should not be taken as an assertion
+    that validation would have succeeded if executed before that point in time.
+    """
+
     # XXX frozenset makes more sense here, but asn1crypto doesn't allow that
     #  (probably legacy behaviour)
     key_usage: ClassVar[Set[str]] = {'non_repudiation'}

--- a/pyhanko/sign/validation/status.py
+++ b/pyhanko/sign/validation/status.py
@@ -17,7 +17,11 @@ from typing import (
 )
 
 from asn1crypto import cms, core, crl, keys, x509
-from pyhanko_certvalidator.errors import PathBuildingError, PathValidationError
+from pyhanko_certvalidator.errors import (
+    PathBuildingError,
+    PathValidationError,
+    ValidationError,
+)
 from pyhanko_certvalidator.path import ValidationPath
 from pyhanko_certvalidator.validate import ACValidationResult
 
@@ -430,7 +434,7 @@ class CAdESSignerAttributeAssertions:
     """
 
     ac_validation_errs: Optional[
-        Collection[Union[PathValidationError, PathBuildingError]]
+        Collection[Union[ValidationError, PathBuildingError]]
     ] = None
     """
     Attribute certificate validation errors.

--- a/pyhanko_tests/data/crypto/certomancer.yml
+++ b/pyhanko_tests/data/crypto/certomancer.yml
@@ -260,6 +260,10 @@ pki-architectures:
         validity:
           valid-from: "2020-01-01T00:00:00+0000"
           valid-to: "2030-01-01T00:00:00+0000"
+      signer1-sha512:
+        subject: signer1
+        digest-algo: sha512
+        template: signer1
     services:
       ocsp:
         interm:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pytz>=2020.1",
     "qrcode>=6.1",
     "tzlocal>=2.1",
-    "pyhanko-certvalidator==0.20.*",
+    "pyhanko-certvalidator==0.21.*,!=0.21.0",
     "click>=7.1.2",
     "requests>=2.24.0",
     "pyyaml>=5.3.1",


### PR DESCRIPTION
## Description of the changes

The discussion in #228 centres on some files with an LTV configuration that has some interesting properties:

 - Signature declared as PAdES
 - No DSS or any DTSes present, the signature covers the entire file.
 - The signature timestamp uses a TSA with a different root.
 - The leaf certificate is very short-lived (i.e. expected to have expired by the time the signature needs to be validated).
 - The file contains an OCSP response for the leaf certificate, but in a `RevInfoArchival` attribute (i.e. not in a DSS), which has no defined role in PAdES.
 - Revocation information for the intermediate CA is not included in the file, so needs to be fetched live.

PyHanko's old validation engine can't cope with some of these characteristics. The new AdES validation deals with them mostly correctly, but the status report is confusing because not all of the information that one would expect actually propagates to the status report. This PR fixes some of those issues.


## Caveats

Upgrades `pyhanko-certvalidator` to `0.21.0`, which includes a minor but breaking change in the exception hierarchy (see [the changelog](https://github.com/MatthiasValvekens/certvalidator/blob/master/changelog.md)).

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [ ] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

