### PR TITLE
Modernise timezone usage

### DIFF
--- a/pyhanko/pdf_utils/misc.py
+++ b/pyhanko/pdf_utils/misc.py
@@ -10,12 +10,12 @@ classes.
 
 import os
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from io import BytesIO
 from typing import Callable, Generator, Iterable, Optional, TypeVar, Union
 
-from pyhanko_certvalidator.util import ConsList
+from pyhanko_certvalidator.util import CancelableAsyncIterator, ConsList
 
 __all__ = [
     'PdfError',
@@ -49,9 +49,6 @@ __all__ = [
     'isoparse',
     'lift_iterable_async',
 ]
-
-import pytz
-from pyhanko_certvalidator import CancelableAsyncIterator
 
 DEFAULT_CHUNK_SIZE = 4096
 """
@@ -542,7 +539,7 @@ def isoparse(dt_str: str) -> datetime:
     dt = parse(dt_str)
     if dt.tzinfo is None:
         # assume UTC
-        dt = dt.replace(tzinfo=pytz.UTC)
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt
 
 

--- a/pyhanko_tests/cli_tests/conftest.py
+++ b/pyhanko_tests/cli_tests/conftest.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import os
-import warnings
 
 import pytest
 import requests_mock
@@ -47,9 +46,7 @@ CERTOMANCER_ARCHITECTURES = {
     "ed25519": TESTING_CA_ED25519,
     "ed448": TESTING_CA_ED448,
 }
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    FREEZE_DT = tzlocal.get_localzone().localize(datetime.datetime(2020, 8, 1))
+FREEZE_DT = datetime.datetime(2020, 8, 1, tzinfo=tzlocal.get_localzone())
 
 
 @pytest.fixture(scope="module", params=list(CERTOMANCER_ARCHITECTURES))

--- a/pyhanko_tests/test_cms.py
+++ b/pyhanko_tests/test_cms.py
@@ -1,12 +1,11 @@
 import hashlib
 import itertools
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from typing import Optional
 
 import pytest
-import pytz
 import tzlocal
 import yaml
 from asn1crypto import algos, cms, core, keys
@@ -276,7 +275,7 @@ async def test_detached_cms_with_tst():
     assert status.signer_reported_dt is None
     assert status.timestamp_validity.intact
     assert status.timestamp_validity.valid
-    assert status.timestamp_validity.timestamp == datetime.now(tz=pytz.utc)
+    assert status.timestamp_validity.timestamp == datetime.now(tz=timezone.utc)
     assert 'The TSA certificate is untrusted' in status.pretty_print_details()
     assert status.valid
     assert status.intact
@@ -302,12 +301,12 @@ async def test_detached_cms_with_content_tst():
     assert status.signer_reported_dt is None
     assert status.timestamp_validity.intact
     assert status.timestamp_validity.valid
-    assert status.timestamp_validity.timestamp == datetime.now(tz=pytz.utc)
+    assert status.timestamp_validity.timestamp == datetime.now(tz=timezone.utc)
     assert status.content_timestamp_validity
     assert status.content_timestamp_validity.intact
     assert status.content_timestamp_validity.valid
     assert status.content_timestamp_validity.timestamp == datetime.now(
-        tz=pytz.utc
+        tz=timezone.utc
     )
     pretty_print = status.pretty_print_details()
     assert 'The TSA certificate is untrusted' in pretty_print
@@ -359,12 +358,12 @@ async def test_detached_cms_with_wrong_tst():
     assert not status.timestamp_validity.intact
     assert status.timestamp_validity.valid
 
-    assert status.timestamp_validity.timestamp == datetime.now(tz=pytz.utc)
+    assert status.timestamp_validity.timestamp == datetime.now(tz=timezone.utc)
     assert status.content_timestamp_validity
     assert status.content_timestamp_validity.intact
     assert status.content_timestamp_validity.valid
     assert status.content_timestamp_validity.timestamp == datetime.now(
-        tz=pytz.utc
+        tz=timezone.utc
     )
     assert status.valid
     assert status.intact
@@ -405,13 +404,13 @@ async def test_detached_cms_with_wrong_content_tst():
     assert status.signer_reported_dt is None
     assert status.timestamp_validity.intact
     assert status.timestamp_validity.valid
-    assert status.timestamp_validity.timestamp == datetime.now(tz=pytz.utc)
+    assert status.timestamp_validity.timestamp == datetime.now(tz=timezone.utc)
     assert status.content_timestamp_validity
     assert not status.content_timestamp_validity.intact
     # internally, the content timestamp is OK
     assert status.content_timestamp_validity.valid
     assert status.content_timestamp_validity.timestamp == datetime.now(
-        tz=pytz.utc
+        tz=timezone.utc
     )
     pretty_print = status.pretty_print_details()
     assert 'The TSA certificate is untrusted' in pretty_print
@@ -1725,10 +1724,10 @@ async def test_detached_cades_cms_with_tst():
     status = await async_validate_detached_cms(
         b'Hello world!', signature['content']
     )
-    assert status.signer_reported_dt == datetime.now(tz=pytz.utc)
+    assert status.signer_reported_dt == datetime.now(tz=timezone.utc)
     assert status.timestamp_validity.intact
     assert status.timestamp_validity.valid
-    assert status.timestamp_validity.timestamp == datetime.now(tz=pytz.utc)
+    assert status.timestamp_validity.timestamp == datetime.now(tz=timezone.utc)
     assert 'The TSA certificate is untrusted' in status.pretty_print_details()
     assert status.valid
     assert status.intact

--- a/pyhanko_tests/test_diff_analysis.py
+++ b/pyhanko_tests/test_diff_analysis.py
@@ -1,10 +1,9 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from itertools import product
 
 import pytest
-import pytz
 from freezegun.api import freeze_time
 
 from pyhanko.pdf_utils import generic, misc
@@ -74,7 +73,7 @@ def test_no_changes_policy():
 
     w = IncrementalPdfFileWriter(out)
     # do an /Info update
-    dt = generic.pdf_date(datetime(2020, 10, 10, tzinfo=pytz.utc))
+    dt = generic.pdf_date(datetime(2020, 10, 10, tzinfo=timezone.utc))
     info = generic.DictionaryObject({pdf_name('/CreationDate'): dt})
     w.set_info(info)
     w.write_in_place()
@@ -116,7 +115,7 @@ def test_double_sig_add_field(file_ix):
     # create a new signature field after signing
     w = IncrementalPdfFileWriter(out)
     # throw in an /Info update for good measure
-    dt = generic.pdf_date(datetime(2020, 10, 10, tzinfo=pytz.utc))
+    dt = generic.pdf_date(datetime(2020, 10, 10, tzinfo=timezone.utc))
     info = generic.DictionaryObject({pdf_name('/CreationDate'): dt})
     w.set_info(info)
 
@@ -163,7 +162,7 @@ def test_double_sig_different_pages():
 
     w = IncrementalPdfFileWriter(out)
     # throw in an /Info update for good measure
-    dt = generic.pdf_date(datetime(2020, 10, 10, tzinfo=pytz.utc))
+    dt = generic.pdf_date(datetime(2020, 10, 10, tzinfo=timezone.utc))
     info = generic.DictionaryObject({pdf_name('/CreationDate'): dt})
     w.set_info(info)
     w.write_in_place()

--- a/pyhanko_tests/test_pades.py
+++ b/pyhanko_tests/test_pades.py
@@ -1,10 +1,9 @@
 import asyncio
-from datetime import datetime
+from datetime import datetime, timezone
 from io import BytesIO
 from typing import Iterable
 
 import pytest
-import pytz
 from asn1crypto import cms, core, tsp
 from certomancer.integrations.illusionist import Illusionist
 from certomancer.registry import ArchLabel, CertLabel, KeyLabel
@@ -837,7 +836,7 @@ def test_add_revinfo_and_timestamp(requests_mock):
             {'trust_roots': TRUST_ROOTS},
         )
         assert status.valid and status.trusted
-        assert status.signer_reported_dt == datetime.now(tz=pytz.utc)
+        assert status.signer_reported_dt == datetime.now(tz=timezone.utc)
 
         # ... but PAdES-LTA should fail
         with pytest.raises(
@@ -884,7 +883,7 @@ def test_add_revinfo_and_lta_timestamp(requests_mock):
             {'trust_roots': TRUST_ROOTS},
         )
         assert status.valid and status.trusted
-        assert status.signer_reported_dt == datetime.now(tz=pytz.utc)
+        assert status.signer_reported_dt == datetime.now(tz=timezone.utc)
 
     # test post-expiration, but before timestamp expires
     with freeze_time('2025-11-01'):

--- a/pyhanko_tests/test_utils.py
+++ b/pyhanko_tests/test_utils.py
@@ -1,13 +1,13 @@
 import datetime
 import itertools
 import os
+from datetime import timezone
 from fractions import Fraction
 from io import BytesIO
 from itertools import product
 from typing import Tuple
 
 import pytest
-import pytz
 
 import pyhanko.pdf_utils.extensions
 from pyhanko.pdf_utils import generic, misc, writer
@@ -24,6 +24,12 @@ from pyhanko.pdf_utils.reader import PdfFileReader, RawPdfPath
 from pyhanko.pdf_utils.rw_common import PdfHandler
 
 from .samples import *
+
+try:
+    import zoneinfo
+except ImportError:
+    # noinspection PyUnresolvedReferences
+    from backports import zoneinfo
 
 
 @pytest.mark.parametrize(
@@ -490,7 +496,7 @@ def test_box_constraint_recalc():
 def test_trailer_update():
     w = IncrementalPdfFileWriter(BytesIO(MINIMAL_ONE_FIELD))
     w._update_meta = lambda: None
-    dt = generic.pdf_date(datetime.datetime(2020, 10, 10, tzinfo=pytz.utc))
+    dt = generic.pdf_date(datetime.datetime(2020, 10, 10, tzinfo=timezone.utc))
 
     info = generic.DictionaryObject({pdf_name('/CreationDate'): dt})
     w.trailer['/Info'] = w.add_object(info)
@@ -576,7 +582,7 @@ TESTDATE_CET = datetime.datetime(
     hour=1,
     minute=5,
     second=59,
-    tzinfo=pytz.timezone('CET'),
+    tzinfo=zoneinfo.ZoneInfo('Europe/Brussels'),
 )
 
 TESTDATE_EST = datetime.datetime(
@@ -586,7 +592,7 @@ TESTDATE_EST = datetime.datetime(
     hour=1,
     minute=5,
     second=59,
-    tzinfo=pytz.timezone('EST'),
+    tzinfo=zoneinfo.ZoneInfo('America/New_York'),
 )
 
 
@@ -617,7 +623,7 @@ TESTDATE_EST = datetime.datetime(
                 hour=1,
                 minute=5,
                 second=59,
-                tzinfo=pytz.utc,
+                tzinfo=timezone.utc,
             ),
         ),
         ('D:20080203010559+01\'00', TESTDATE_CET),
@@ -1401,17 +1407,29 @@ def test_parse_name_invalid_utf8():
     [
         (
             datetime.datetime(
-                2020, 12, 26, 15, 5, 11, tzinfo=pytz.timezone('EST')
+                2020,
+                12,
+                26,
+                15,
+                5,
+                11,
+                tzinfo=zoneinfo.ZoneInfo('America/New_York'),
             ),
             "D:20201226150511-05'00'",
         ),
         (
-            datetime.datetime(2020, 12, 26, 15, 5, 11, tzinfo=pytz.utc),
+            datetime.datetime(2020, 12, 26, 15, 5, 11, tzinfo=timezone.utc),
             "D:20201226150511Z",
         ),
         (
             datetime.datetime(
-                2020, 12, 26, 15, 5, 11, tzinfo=pytz.timezone('CET')
+                2020,
+                12,
+                26,
+                15,
+                5,
+                11,
+                tzinfo=zoneinfo.ZoneInfo('Europe/Brussels'),
             ),
             "D:20201226150511+01'00'",
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,8 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "asn1crypto>=1.5.1",
-    "pytz>=2020.1",
     "qrcode>=6.1",
-    "tzlocal>=2.1",
+    "tzlocal>=4.3",
     "pyhanko-certvalidator==0.22.*",
     "click>=7.1.2",
     "requests>=2.24.0",
@@ -82,6 +81,7 @@ testing-basic = [
     "pytest-asyncio==0.21.0",
     "certomancer~=0.9.1",
     "pytest-cov~=4.0.0",
+    "backports.zoneinfo[tzdata];python_version<\"3.9\"",
 ]
 testing = [
     "pyHanko[testing-basic,pkcs11,xmp,opentype,image-support,async-http,extra-pubkey-algs]",
@@ -100,7 +100,6 @@ mypy = [
     "pyHanko[pkcs11,xmp,opentype,image-support,async-http,extra-pubkey-algs]",
     "types-requests",
     "types-python-dateutil",
-    "types-pytz",
     "types-PyYAML",
     "types-tzlocal",
 ]


### PR DESCRIPTION
## Description of the changes

 - Remove dependency on pytz
 - Add fallback dependency on zoneinfo for older pythons
 - Get rid of .localize calls (fixes #256)

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

(The decrease in coverage is from import statements being removed, which is no big deal)
