### PR TITLE
Treat nulls the same as missing entries in dicts

### DIFF
--- a/pyhanko/pdf_utils/generic.py
+++ b/pyhanko/pdf_utils/generic.py
@@ -1201,7 +1201,11 @@ class DictionaryObject(dict, PdfObject):
                 raw_obj.reference, as_metadata_stream=True
             )
         else:
-            return raw_obj.get_object()
+            deref_obj = raw_obj.get_object()
+            if isinstance(deref_obj, NullObject):
+                raise KeyError(key)
+            else:
+                return deref_obj
 
     def get_and_apply(
         self,

--- a/pyhanko_tests/test_diff_analysis.py
+++ b/pyhanko_tests/test_diff_analysis.py
@@ -530,7 +530,7 @@ def test_form_field_ft_tamper():
 
 
 BOGUS_KIDS_VALUES = [
-    (generic.NullObject(), False),
+    (generic.NameObject('/Test'), False),
     (generic.ArrayObject(), False),
     (generic.ArrayObject([generic.NullObject()]), False),
     (generic.ArrayObject([generic.NullObject()]), True),

--- a/pyhanko_tests/test_fields.py
+++ b/pyhanko_tests/test_fields.py
@@ -453,6 +453,20 @@ def test_append_acroform_no_fields():
         fields.append_signature_field(w, sp)
 
 
+def test_append_acroform_reference_broken_nonstrict():
+    w = PdfFileWriter()
+    w.insert_page(simple_page(w, 'Hello world'))
+    # in nonstrict mode, this should be functionally equivalent to a null
+    w.root['/AcroForm'] = generic.IndirectObject(1239481, 0, w)
+    out = BytesIO()
+    w.write(out)
+
+    sp = fields.SigFieldSpec('InvisibleSig')
+    w = IncrementalPdfFileWriter(out, strict=False)
+    fields.append_signature_field(w, sp)
+    assert len(w.root['/AcroForm']['/Fields']) == 1
+
+
 def test_circular_form_tree_sign():
     fname = os.path.join(PDF_DATA_DIR, 'form-tree-circular-ref-input.pdf')
     with open(fname, 'rb') as inf:

--- a/pyhanko_tests/test_seed_values.py
+++ b/pyhanko_tests/test_seed_values.py
@@ -168,7 +168,9 @@ def test_sv_mdp_type():
         )
     with pytest.raises(SigningError):
         fields.SigSeedValueSpec.from_pdf_object(
-            generic.DictionaryObject({pdf_name('/MDP'): generic.NullObject()})
+            generic.DictionaryObject(
+                {pdf_name('/MDP'): generic.NumberObject(5)}
+            )
         )
 
 

--- a/pyhanko_tests/test_utils.py
+++ b/pyhanko_tests/test_utils.py
@@ -1821,3 +1821,30 @@ def test_dictionary_setvalue_guard():
         dict_obj['/A'] = 1
     with pytest.raises(ValueError, match='must be PdfObject'):
         dict_obj.setdefault(pdf_name('/A'), 1)
+
+
+def test_all_nulls_equal():
+    assert generic.NullObject() == generic.NullObject()
+
+
+def test_all_nulls_same_hash():
+    assert hash(generic.NullObject()) == hash(generic.NullObject())
+
+
+def test_null_is_missing():
+    d = generic.DictionaryObject(
+        {
+            generic.pdf_name('/A'): generic.NameObject('/Z'),
+            generic.pdf_name('/B'): generic.NullObject(),
+        }
+    )
+
+    assert d['/A'] == '/Z'
+    with pytest.raises(KeyError):
+        d.__getitem__('/B')
+
+    with pytest.raises(KeyError):
+        d.__getitem__(generic.pdf_name('/B'))
+
+    with pytest.raises(KeyError):
+        d.__getitem__('/C')


### PR DESCRIPTION
## Description of the changes

Compliance point: nulls should be treated equivalently to missing entries in dictionaries (not in arrays, though!) per the processor requirements in the PDF spec.

Issue #261 was a symptom of this, and is addressed by this fix (in nonstrict mode only; pyHanko deliberately does not substitute nulls for unresolvable references in strict mode, even though that is what the letter of the spec requires).

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

