### PR TITLE
Run non-crypto CLI commands with strict=False

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -32,7 +32,8 @@ For API users, that means passing ``strict=False`` to any
 :class:`~pyhanko.pdf_utils.reader.PdfFileReader` objects that could touch hybrid files.
 
 For CLI users, there's the ``--no-strict-syntax`` switch, which is available for both signing
-and validation subcommands.
+and validation subcommands. Non-cryptographic CLI subcommands (e.g. ``stamp`` and ``addfields``)
+always open files in nonstrict mode.
 
 
 Why am I getting path building errors?

--- a/pyhanko/cli/commands/fields.py
+++ b/pyhanko/cli/commands/fields.py
@@ -23,7 +23,7 @@ __all__ = ['list_sigfields', 'add_sig_field']
 )
 def list_sigfields(infile, skip_status):
     with pyhanko_exception_manager():
-        r = PdfFileReader(infile)
+        r = PdfFileReader(infile, strict=False)
         field_info = fields.enumerate_sig_fields(r)
         for ix, (name, value, field_ref) in enumerate(field_info):
             if skip_status:
@@ -42,7 +42,7 @@ def list_sigfields(infile, skip_status):
 )
 def add_sig_field(infile, outfile, field):
     with pyhanko_exception_manager():
-        writer = IncrementalPdfFileWriter(infile)
+        writer = IncrementalPdfFileWriter(infile, strict=False)
 
         for s in field:
             name, spec = parse_field_location_spec(s)

--- a/pyhanko/stamp.py
+++ b/pyhanko/stamp.py
@@ -859,7 +859,7 @@ def _stamp_file(
     **stamp_kwargs,
 ):
     with open(input_name, 'rb') as fin:
-        pdf_out = IncrementalPdfFileWriter(fin)
+        pdf_out = IncrementalPdfFileWriter(fin, strict=False)
         stamp = stamp_class(writer=pdf_out, style=style, **stamp_kwargs)
         stamp.apply(dest_page, x, y)
 


### PR DESCRIPTION
## Description of the changes

Turn off strict mode in non-cryptographic CLI commands. Being very particular about semantics isn't as big of a deal when there's no cryptographic commitment involved.

Fixes #262.

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

## Additional comments

Feel free to add any additional comments here.
