### PR TITLE
Fix signature rotation with rotate_with_page == false

### DIFF
--- a/pyhanko/pdf_utils/content.py
+++ b/pyhanko/pdf_utils/content.py
@@ -184,7 +184,7 @@ class PdfContent:
         resources: Optional[PdfResources] = None,
         box: Optional[BoxConstraints] = None,
         writer: Optional[BasePdfFileWriter] = None,
-        matrix: Optional[generic.ArrayObject] = None
+        matrix: Optional[generic.DictionaryObject] = None
     ):
         self._resources: PdfResources = resources or PdfResources()
         self.box: BoxConstraints = box or BoxConstraints()
@@ -312,7 +312,7 @@ class RawContent(PdfContent):
         data: bytes,
         resources: Optional[PdfResources] = None,
         box: Optional[BoxConstraints] = None,
-        matrix: Optional[generic.ArrayObject] = None
+        matrix: Optional[generic.DictionaryObject] = None
     ):
         super().__init__(resources, box, matrix=matrix)
         self.data = data

--- a/pyhanko/pdf_utils/content.py
+++ b/pyhanko/pdf_utils/content.py
@@ -2,7 +2,7 @@ import binascii
 import uuid
 from enum import Enum
 from typing import Optional
-
+from pyhanko.pdf_utils import generic
 from .generic import (
     DictionaryObject,
     NameObject,
@@ -167,6 +167,11 @@ class PdfContent:
 
     writer = None
     """
+    Transformation Matrix that would rotate the content
+    """
+
+    matrix = None
+    """
     The :meth:`__init__` method comes with an optional ``writer`` 
     parameter that can be used to let subclasses register external resources 
     with the writer by themselves.
@@ -179,10 +184,12 @@ class PdfContent:
         resources: Optional[PdfResources] = None,
         box: Optional[BoxConstraints] = None,
         writer: Optional[BasePdfFileWriter] = None,
+        matrix: Optional[generic.ArrayObject] = None
     ):
         self._resources: PdfResources = resources or PdfResources()
         self.box: BoxConstraints = box or BoxConstraints()
         self.writer = writer
+        self.matrix = matrix
 
     @property
     def _ensure_writer(self) -> BasePdfFileWriter:
@@ -254,6 +261,7 @@ class PdfContent:
             box_width=self.box.width,
             box_height=self.box.height,
             resources=self._resources.as_pdf_object(),
+            matrix=self.matrix
         )
 
     def set_writer(self, writer):
@@ -304,8 +312,9 @@ class RawContent(PdfContent):
         data: bytes,
         resources: Optional[PdfResources] = None,
         box: Optional[BoxConstraints] = None,
+        matrix: Optional[generic.ArrayObject] = None
     ):
-        super().__init__(resources, box)
+        super().__init__(resources, box, matrix=matrix)
         self.data = data
 
     def render(self) -> bytes:

--- a/pyhanko/pdf_utils/writer.py
+++ b/pyhanko/pdf_utils/writer.py
@@ -60,6 +60,7 @@ def init_xobject_dictionary(
     box_width,
     box_height,
     resources: Optional[generic.DictionaryObject] = None,
+    matrix: Optional[generic.DictionaryObject] = None
 ) -> generic.StreamObject:
     """
     Helper function to initialise form XObject dictionaries.
@@ -79,8 +80,7 @@ def init_xobject_dictionary(
         A :class:`~.generic.StreamObject` representation of the form XObject.
     """
     resources = resources or generic.DictionaryObject()
-    return generic.StreamObject(
-        {
+    dict_data = {
             pdf_name('/BBox'): generic.ArrayObject(
                 list(
                     map(generic.FloatObject, (0.0, box_height, box_width, 0.0))
@@ -89,7 +89,14 @@ def init_xobject_dictionary(
             pdf_name('/Resources'): resources,
             pdf_name('/Type'): pdf_name('/XObject'),
             pdf_name('/Subtype'): pdf_name('/Form'),
-        },
+        }
+    if matrix is not None:
+        dict_data[pdf_name('/Matrix')] = generic.ArrayObject(
+                list(
+                    map(generic.FloatObject, matrix)
+                )
+            )
+    return generic.StreamObject(dict_data,
         stream_data=command_stream,
     )
 

--- a/pyhanko/sign/fields.py
+++ b/pyhanko/sign/fields.py
@@ -1671,17 +1671,12 @@ def append_signature_field(
             while '/Parent' in pagetree_obj and ('/Type' not in pagetree_obj or pagetree_obj['/Type'] != '/Page'):
                 pagetree_obj = pagetree_obj['/Parent']
             if '/Rotate' in pagetree_obj:
-                match pagetree_obj['/Rotate']:
-                    case 0:
-                        matrix = (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
-                    case 90:
-                        matrix = (0.0, 1.0, -1.0, 0.0, 0.0, 0.0)
-                    case 180:
-                        matrix = (-1.0, 0.0, 0.0, -1.0, 0.0, 0.0)
-                    case 270:
-                        matrix = (0.0, -1.0, 1.0, 0.0, 0.0, 0.0)
-            else:
-                matrix = (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+                if pagetree_obj['/Rotate'] == 90:
+                    matrix = [0.0, 1.0, -1.0, 0.0, 0.0, 0.0]
+                elif pagetree_obj['/Rotate'] == 180:
+                    matrix = [-1.0, 0.0, 0.0, -1.0, 0.0, 0.0]
+                elif pagetree_obj['/Rotate'] == 270:
+                    matrix = [0.0, -1.0, 1.0, 0.0, 0.0, 0.0]
         w = abs(urx - llx)
         h = abs(ury - lly)
         if w and h:

--- a/pyhanko/sign/fields.py
+++ b/pyhanko/sign/fields.py
@@ -1781,10 +1781,25 @@ class SignatureFormField(generic.DictionaryObject):
                     annot_flags |= 0b100
                 if not visible_settings.scale_with_page_zoom:
                     annot_flags |= 0b1000
-                if not visible_settings.rotate_with_page:
-                    annot_flags |= 0b10000
+                # this actually breaks signatures
+                # if not visible_settings.rotate_with_page:
+                #     annot_flags |= 0b10000
 
         annot_dict['/F'] = generic.NumberObject(annot_flags)
+
+        if visible_settings.rotate_with_page == False:
+            pagetree_obj = include_on_page.get_object()
+            while '/Parent' in pagetree_obj and ('/Type' not in pagetree_obj or pagetree_obj['/Type'] != '/Page'):
+                pagetree_obj = pagetree_obj['/Parent']
+            if '/Rotate' in pagetree_obj:
+                if pagetree_obj['/Rotate'] == 90:
+                    #This only rotates it around the top left corner of the box
+                    #Goal is to make it stay on the same coordinates, no matter if its portrait or landscape
+                    rect = [generic.FloatObject(rect[0]), generic.FloatObject(rect[1]), generic.FloatObject((rect[3] - rect[1]) * -1 + rect[0]), generic.FloatObject(rect[2] - rect[0] + rect[1])]
+                elif pagetree_obj['/Rotate'] == 180:
+                    rect = rect # TODO
+                elif pagetree_obj['/Rotate'] == 270:
+                    rect = rect # TODO
         annot_dict['/Rect'] = generic.ArrayObject(rect)
 
         self.page_ref = include_on_page

--- a/pyhanko/sign/fields.py
+++ b/pyhanko/sign/fields.py
@@ -1665,6 +1665,23 @@ def append_signature_field(
 
     if sig_field_spec.box is not None:
         llx, lly, urx, ury = sig_field_spec.box
+        matrix = None
+        if sig_field_spec.visible_sig_settings.rotate_with_page == False:
+            pagetree_obj = page_ref.get_object()
+            while '/Parent' in pagetree_obj and ('/Type' not in pagetree_obj or pagetree_obj['/Type'] != '/Page'):
+                pagetree_obj = pagetree_obj['/Parent']
+            if '/Rotate' in pagetree_obj:
+                match pagetree_obj['/Rotate']:
+                    case 0:
+                        matrix = (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
+                    case 90:
+                        matrix = (0.0, 1.0, -1.0, 0.0, 0.0, 0.0)
+                    case 180:
+                        matrix = (-1.0, 0.0, 0.0, -1.0, 0.0, 0.0)
+                    case 270:
+                        matrix = (0.0, -1.0, 1.0, 0.0, 0.0, 0.0)
+            else:
+                matrix = (1.0, 0.0, 0.0, 1.0, 0.0, 0.0)
         w = abs(urx - llx)
         h = abs(ury - lly)
         if w and h:
@@ -1682,10 +1699,12 @@ def append_signature_field(
                 ap_stream = RawContent(
                     b' '.join(appearance_cmds),
                     box=BoxConstraints(width=w, height=h),
+                    matrix=matrix
                 ).as_form_xobject()
             else:
                 ap_stream = RawContent(
-                    b'', box=BoxConstraints(width=w, height=h)
+                    b'', box=BoxConstraints(width=w, height=h),
+                    matrix=matrix
                 ).as_form_xobject()
             ap_dict[pdf_name('/N')] = pdf_out.add_object(ap_stream)
 

--- a/pyhanko/sign/signers/cms_embedder.py
+++ b/pyhanko/sign/signers/cms_embedder.py
@@ -266,10 +266,11 @@ class SigAppearanceSetup:
             stamp = self._appearance_stamp(
                 writer, BoxConstraints(width=w, height=h)
             )
-            normalappearence = stamp.as_appearances()
-            if '/Matrix' in sig_annot:
-                normalappearence['/Matrix'] = sig_annot['/Matrix']
-            sig_annot['/AP'] = normalappearence.as_pdf_object()
+            normalappearence = stamp.as_appearances().as_pdf_object()
+            # Remove this when appearence stream in sig_annot['/AP'] is no longer replaced with the one from 'normalappearence'
+            if '/AP' in sig_annot and '/N' in sig_annot['/AP'] and '/Matrix' in sig_annot['/AP']['/N']:
+                normalappearence['/N']['/Matrix'] = sig_annot['/AP']['/N']['/Matrix']
+            sig_annot['/AP'] = normalappearence
             try:
                 # if there was an entry like this, it's meaningless now
                 del sig_annot[pdf_name('/AS')]

--- a/pyhanko/sign/signers/cms_embedder.py
+++ b/pyhanko/sign/signers/cms_embedder.py
@@ -266,7 +266,10 @@ class SigAppearanceSetup:
             stamp = self._appearance_stamp(
                 writer, BoxConstraints(width=w, height=h)
             )
-            sig_annot['/AP'] = stamp.as_appearances().as_pdf_object()
+            normalappearence = stamp.as_appearances()
+            if '/Matrix' in sig_annot:
+                normalappearence['/Matrix'] = sig_annot['/Matrix']
+            sig_annot['/AP'] = normalappearence.as_pdf_object()
             try:
                 # if there was an entry like this, it's meaningless now
                 del sig_annot[pdf_name('/AS')]


### PR DESCRIPTION
## Description of the changes

Adds a counter rotation to a signature if it is added to a rotated pdf while rotate_with_page is false (See Issue https://github.com/MatthiasValvekens/pyHanko/issues/265)

## Caveats

Currently this solution adds the transformation matrix to the signature field first and then copies it to the appearence of the signature. This could be prevented if the already added /N field is reused instead of overwritten.
Note: /N or rather /AP was added twice even without my change, once in fields.py at `ap_dict[pdf_name('/N')] = pdf_out.add_object(ap_stream)` and once in cms_embedder.py where my change adds the /Matrix field

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] My changes do not affect any public API or CLI semantics.
 - [ ] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 -> I honestly dont know how to add this
 - [ ] All new code in this PR has full test coverage.
-> Also dont know how to ensure this

## Additional comments

I know that my solution is not perfect, since it creates a transformation matrix field that wont be used by the pdf in any way, but with the bug where 2 appearence objects are created, this was the only solution i could think of without also having to fix that.

I wouldnt mind if you reject this PR because of this, but i hope this can at least help you with fixing the bug.