### PR TITLE
Support RSAES-OAEP for file encryption

### DIFF
--- a/pyhanko/pdf_utils/embed.py
+++ b/pyhanko/pdf_utils/embed.py
@@ -12,6 +12,7 @@ from typing import List, Optional
 from asn1crypto import x509
 
 from . import crypt, generic, misc, writer
+from .crypt.pubkey import RecipientEncryptionPolicy
 from .font.basic import get_courier
 from .generic import pdf_name, pdf_string
 
@@ -451,7 +452,7 @@ def wrap_encrypted_payload(
                     default_file_filter=crypt.DEF_EMBEDDED_FILE,
                 ),
             )
-            pubkey_cf.add_recipients(certs)
+            pubkey_cf.add_recipients(certs, policy=RecipientEncryptionPolicy())
         else:
             # set up standard security handler
             std_cf = crypt.StandardAESCryptFilter(keylen=32)


### PR DESCRIPTION
## Description of the changes

This algorithm choice isn't widely supported in the field in viewers, and the public-key security handler for file encryption in PDF is not widely used in general either, but this change was straightforward to implement, so I added it.


## Caveats

This is in a grey area of the PDF spec (=> it's silent on this topic), and Acrobat only supports PKCS#1 v1.5 padding. It does support other algorithms that are not explicitly in the spec, though (in particular using ECDHE to do non-interactive key agreement for file encryption).

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.
