### PR TITLE
Improve ad-hoc field creation UX in CLI

### DIFF
--- a/docs/cli-guide/signing.rst
+++ b/docs/cli-guide/signing.rst
@@ -196,7 +196,13 @@ have a ``.pfx`` or ``.p12`` extension) as follows:
 By default, these calls create invisible signature fields, but if the field
 specified using the ``--field`` parameter exists and has a widget associated
 with it, a simple default appearance will be generated
-(see :numref:`default-appearance`).
+(see :numref:`default-appearance`). You can also use the extended syntax from
+``addfields`` to create visible signature fields on-the-fly, e.g. like so:
+
+.. code-block:: bash
+
+    pyhanko sign addsig --field PAGE/X1,Y1,X2,Y2/NAME pkcs12 \
+        input.pdf output.pdf secrets.pfx
 
 In many cases, you may want to embed extra certificates (e.g. for intermediate
 certificate authorities) into your signature, to facilitate validation.

--- a/pyhanko/cli/_ctx.py
+++ b/pyhanko/cli/_ctx.py
@@ -1,10 +1,25 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 from pyhanko.cli.config import CLIConfig
 from pyhanko.sign import PdfSignatureMetadata
 from pyhanko.sign.fields import SigFieldSpec
 from pyhanko.stamp import BaseStampStyle
+
+
+@dataclass
+class UXContext:
+    """
+    Context object to track information that affects the UX, e.g. user intent
+    as inferred from certain argument combinations that are otherwise difficult
+    to wire throughout the UI code.
+    """
+
+    visible_signature_desired: bool = False
+    """
+    Set to `True` if the user explicitly specifies `--field` with a bounding box
+    or passes `--style-name` explicitly.
+    """
 
 
 @dataclass
@@ -26,7 +41,7 @@ class CLIContext:
 
     config: Optional[CLIConfig] = None
     """
-    Valuse for CLI configuration settings.
+    Values for CLI configuration settings.
     """
 
     existing_fields_only: bool = False
@@ -69,4 +84,9 @@ class CLIContext:
     lenient: bool = False
     """
     Process PDF files in nonstrict mode.
+    """
+
+    ux: UXContext = field(default_factory=UXContext)
+    """
+    UX information.
     """

--- a/pyhanko/cli/commands/signing/__init__.py
+++ b/pyhanko/cli/commands/signing/__init__.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import click
 from pyhanko_certvalidator import ValidationContext
@@ -203,6 +203,7 @@ def addsig(
             key_usage = key_usage_sett.key_usage
     else:
         vc = None
+    field_name: Optional[str]
     if field:
         field_name, new_field_spec = parse_field_location_spec(
             field, require_full_spec=False
@@ -230,6 +231,7 @@ def addsig(
     ctx_obj.stamp_style = select_style(ctx, style_name, stamp_url)
     ctx_obj.stamp_url = stamp_url
     ctx_obj.lenient = no_strict_syntax
+    ctx_obj.ux.visible_signature_desired = bool(style_name or new_field_spec)
 
 
 def register(plugins: List[SigningCommandPlugin]):

--- a/pyhanko/cli/commands/signing/__init__.py
+++ b/pyhanko/cli/commands/signing/__init__.py
@@ -209,6 +209,10 @@ def addsig(
         )
     else:
         field_name = new_field_spec = None
+    if new_field_spec and existing_only:
+        raise click.ClickException(
+            "Specifying field coordinates is incompatible with --existing-only"
+        )
     ctx_obj.sig_settings = signers.PdfSignatureMetadata(
         field_name=field_name,
         location=location,

--- a/pyhanko/cli/utils.py
+++ b/pyhanko/cli/utils.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional, Tuple
 
 import click
 
@@ -40,7 +41,9 @@ def _index_page(page):
         )
 
 
-def parse_field_location_spec(spec, require_full_spec=True):
+def parse_field_location_spec(
+    spec: str, require_full_spec: bool = True
+) -> Tuple[str, Optional[fields.SigFieldSpec]]:
     try:
         page, box, name = spec.split('/')
     except ValueError:

--- a/pyhanko/sign/signers/cms_embedder.py
+++ b/pyhanko/sign/signers/cms_embedder.py
@@ -15,9 +15,11 @@ from pyhanko.sign.fields import (
     FieldMDPSpec,
     MDPPerm,
     SigFieldSpec,
+    annot_width_height,
     apply_sig_field_spec_properties,
     ensure_sig_flags,
     enumerate_sig_fields,
+    get_sig_field_annot,
     prepare_sig_field,
 )
 from pyhanko.sign.general import SigningError
@@ -254,12 +256,7 @@ class SigAppearanceSetup:
             This method is internal API.
         """
 
-        try:
-            x1, y1, x2, y2 = sig_annot['/Rect']
-        except KeyError:
-            return
-        w = abs(x1 - x2)
-        h = abs(y1 - y2)
+        w, h = annot_width_height(sig_annot)
         if w and h:
             # the field is probably a visible one, so we change its appearance
             # stream to show some data about the signature
@@ -467,18 +464,7 @@ class PdfCMSEmbedder:
         # take care of the field's visual appearance (if applicable)
         appearance_setup = sig_obj_setup.appearance_setup
         if appearance_setup is not None:
-            try:
-                (sig_annot,) = sig_field['/Kids']
-                sig_annot = sig_annot.get_object()
-            except (ValueError, TypeError):
-                raise SigningError(
-                    "Failed to access signature field's annotation. "
-                    "Signature field must have exactly one child annotation, "
-                    "or it must be combined with its annotation."
-                )
-            except KeyError:
-                sig_annot = sig_field
-
+            sig_annot = get_sig_field_annot(sig_field)
             appearance_setup.apply(sig_annot, writer)
 
         sig_obj = sig_obj_setup.sig_placeholder

--- a/pyhanko_tests/cli_tests/test_cli_signing.py
+++ b/pyhanko_tests/cli_tests/test_cli_signing.py
@@ -902,3 +902,26 @@ def test_cli_sign_visible_with_style_but_no_config(
     )
     assert result.exit_code == 1
     assert "requires a configuration file" in result.output
+
+
+def test_cli_new_field_spec_bars_existing_only(cli_runner):
+    result = cli_runner.invoke(
+        cli_root,
+        [
+            'sign',
+            'addsig',
+            '--field',
+            '1/0,0,100,100/Sig1',
+            '--existing-only',
+            'pemder',
+            '--no-pass',
+            '--cert',
+            _write_cert(TESTING_CA, CertLabel('signer1'), "cert.pem"),
+            '--key',
+            _write_user_key(TESTING_CA),
+            INPUT_PATH,
+            SIGNED_OUTPUT_PATH,
+        ],
+    )
+    assert result.exit_code == 1
+    assert "incompatible with --existing-only" in result.output


### PR DESCRIPTION
## Description of the changes

When creating fields together with a signature, the CLI currently does not always do the "obvious" thing. In particular, certain combinations of parameters that don't really make sense are still processed with sometimes counterintuitive results. This PR adds error handling and more informative failure messages for such cases. It also adds a point of clarification to the documentation regarding the `--field` argument to `addsig` in the CLI usage guide.

See #272 for the question that prompted this change. (CC: @regonzalom)

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.


### For documentation contributions (delete if not applicable)

 - [x] I have built the HTML documentation locally, and verified that the changes behave correctly in-browser.
