### PR TITLE
Tolerate missing `D:` in date strings

### DIFF
--- a/pyhanko/pdf_utils/generic.py
+++ b/pyhanko/pdf_utils/generic.py
@@ -2154,18 +2154,19 @@ def pdf_date(dt: datetime) -> TextStringObject:
 
 # The year field is the only mandatory one
 MIN_DATE_REGEX = re.compile(r'^D:(\d{4})')
+MIN_DATE_REGEX_LENIENT = re.compile(r'^(?:D:)?(\d{4})')
 TWO_DIGIT_START = re.compile(r'^(\d\d)')
 UTC_OFFSET = re.compile(r"(\d\d)(?:'(\d\d))?'?")
 
 
-def parse_pdf_date(date_str: str) -> datetime:
-    m = MIN_DATE_REGEX.match(date_str)
+def parse_pdf_date(date_str: str, strict: bool = True) -> datetime:
+    m = (MIN_DATE_REGEX if strict else MIN_DATE_REGEX_LENIENT).match(date_str)
     if not m:
         raise PdfReadError(f"{date_str} does not appear to be a date string.")
     year = int(m.group(1))
 
     # now, there are a number of 2-digit groups (anywhere from 0 to 5)
-    date_remaining = date_str[6:]
+    date_remaining = date_str[m.end(0) :]
     lower_order = [1, 1, 0, 0, 0]
 
     for ix in range(5):

--- a/pyhanko/pdf_utils/metadata/info.py
+++ b/pyhanko/pdf_utils/metadata/info.py
@@ -108,7 +108,7 @@ def update_info_dict(
 
 
 def _read_date_from_dict(
-    info_dict: generic.DictionaryObject, key: str
+    info_dict: generic.DictionaryObject, key: str, strict: bool
 ) -> Optional[datetime]:
     try:
         date_str = info_dict[key]
@@ -117,7 +117,7 @@ def _read_date_from_dict(
 
     try:
         if isinstance(date_str, generic.TextStringObject):
-            return generic.parse_pdf_date(date_str)
+            return generic.parse_pdf_date(date_str, strict=strict)
     except misc.PdfReadError:
         pass
 
@@ -130,7 +130,7 @@ def _read_date_from_dict(
 
 
 def view_from_info_dict(
-    info_dict: generic.DictionaryObject,
+    info_dict: generic.DictionaryObject, strict: bool = True
 ) -> model.DocumentMetadata:
     kwargs: Dict[str, Any] = {}
     for s_entry in ('title', 'author', 'subject', 'creator'):
@@ -139,11 +139,13 @@ def view_from_info_dict(
         except KeyError:
             pass
 
-    creation_date = _read_date_from_dict(info_dict, '/CreationDate')
+    creation_date = _read_date_from_dict(
+        info_dict, '/CreationDate', strict=strict
+    )
     if creation_date is not None:
         kwargs['created'] = creation_date
 
-    mod_date = _read_date_from_dict(info_dict, '/ModDate')
+    mod_date = _read_date_from_dict(info_dict, '/ModDate', strict=strict)
     if mod_date is not None:
         kwargs['last_modified'] = mod_date
 

--- a/pyhanko/pdf_utils/reader.py
+++ b/pyhanko/pdf_utils/reader.py
@@ -188,7 +188,7 @@ class PdfFileReader(PdfHandler):
         except KeyError:
             return DocumentMetadata()
 
-        return view_from_info_dict(info_dict)
+        return view_from_info_dict(info_dict, strict=self.strict)
 
     @property
     def input_version(self):
@@ -807,7 +807,7 @@ class HistoricalResolver(PdfHandler):
         except KeyError:
             return DocumentMetadata()
 
-        return view_from_info_dict(info_dict)
+        return view_from_info_dict(info_dict, strict=self.reader.strict)
 
     @property
     def document_id(self) -> Tuple[bytes, bytes]:

--- a/pyhanko/sign/validation/pdf_embedded.py
+++ b/pyhanko/sign/validation/pdf_embedded.py
@@ -272,7 +272,8 @@ class EmbeddedPdfSignature:
         """
         :return:
             The signing time as reported by the signer, if embedded in the
-            signature's signed attributes.
+            signature's signed attributes or provided as part of the signature
+            object in the PDF document.
         """
         ts = extract_self_reported_ts(self.signer_info)
         if ts is not None:
@@ -280,7 +281,9 @@ class EmbeddedPdfSignature:
 
         try:
             st_as_pdf_date = self.sig_object['/M']
-            return generic.parse_pdf_date(st_as_pdf_date)
+            return generic.parse_pdf_date(
+                st_as_pdf_date, strict=self.reader.strict
+            )
         except KeyError:  # pragma: nocover
             return None
 

--- a/pyhanko_tests/test_utils.py
+++ b/pyhanko_tests/test_utils.py
@@ -601,48 +601,55 @@ TESTDATE_EST = datetime.datetime(
 )
 
 
-@pytest.mark.parametrize(
-    'date_str, expected_dt',
-    [
-        ('D:2008', datetime.datetime(year=2008, month=1, day=1)),
-        ('D:200802', datetime.datetime(year=2008, month=2, day=1)),
-        ('D:20080203', datetime.datetime(year=2008, month=2, day=3)),
-        ('D:20080201', datetime.datetime(year=2008, month=2, day=1)),
-        ('D:2008020301', datetime.datetime(year=2008, month=2, day=3, hour=1)),
-        (
-            'D:200802030105',
-            datetime.datetime(year=2008, month=2, day=3, hour=1, minute=5),
+DATE_PAIRS = [
+    ('D:2008', datetime.datetime(year=2008, month=1, day=1)),
+    ('D:200802', datetime.datetime(year=2008, month=2, day=1)),
+    ('D:20080203', datetime.datetime(year=2008, month=2, day=3)),
+    ('D:20080201', datetime.datetime(year=2008, month=2, day=1)),
+    ('D:2008020301', datetime.datetime(year=2008, month=2, day=3, hour=1)),
+    (
+        'D:200802030105',
+        datetime.datetime(year=2008, month=2, day=3, hour=1, minute=5),
+    ),
+    (
+        'D:20080203010559',
+        datetime.datetime(
+            year=2008, month=2, day=3, hour=1, minute=5, second=59
         ),
-        (
-            'D:20080203010559',
-            datetime.datetime(
-                year=2008, month=2, day=3, hour=1, minute=5, second=59
-            ),
+    ),
+    (
+        'D:20080203010559Z',
+        datetime.datetime(
+            year=2008,
+            month=2,
+            day=3,
+            hour=1,
+            minute=5,
+            second=59,
+            tzinfo=timezone.utc,
         ),
-        (
-            'D:20080203010559Z',
-            datetime.datetime(
-                year=2008,
-                month=2,
-                day=3,
-                hour=1,
-                minute=5,
-                second=59,
-                tzinfo=timezone.utc,
-            ),
-        ),
-        ('D:20080203010559+01\'00', TESTDATE_CET),
-        ('D:20080203010559+01', TESTDATE_CET),
-        ('D:20080203010559+01\'', TESTDATE_CET),
-        ('D:20080203010559+01\'00\'', TESTDATE_CET),
-        ('D:20080203010559-05\'00', TESTDATE_EST),
-        ('D:20080203010559-05', TESTDATE_EST),
-        ('D:20080203010559-05\'', TESTDATE_EST),
-        ('D:20080203010559-05\'00\'', TESTDATE_EST),
-    ],
-)
+    ),
+    ('D:20080203010559+01\'00', TESTDATE_CET),
+    ('D:20080203010559+01', TESTDATE_CET),
+    ('D:20080203010559+01\'', TESTDATE_CET),
+    ('D:20080203010559+01\'00\'', TESTDATE_CET),
+    ('D:20080203010559-05\'00', TESTDATE_EST),
+    ('D:20080203010559-05', TESTDATE_EST),
+    ('D:20080203010559-05\'', TESTDATE_EST),
+    ('D:20080203010559-05\'00\'', TESTDATE_EST),
+]
+
+
+@pytest.mark.parametrize('date_str, expected_dt', DATE_PAIRS)
 def test_date_parsing(date_str, expected_dt):
     assert generic.parse_pdf_date(date_str) == expected_dt
+
+
+@pytest.mark.parametrize(
+    'date_str, expected_dt', [(dt_str[2:], dt) for dt_str, dt in DATE_PAIRS]
+)
+def test_date_parsing_without_prefix(date_str, expected_dt):
+    assert generic.parse_pdf_date(date_str, strict=False) == expected_dt
 
 
 @pytest.mark.parametrize(
@@ -655,6 +662,7 @@ def test_date_parsing(date_str, expected_dt):
         'D:20030230',
         'D:20080203010559Z00',
         'D:20080203010559-05\'00\'11',
+        '20230719131933+02\'00\'',
     ],
 )
 def test_date_parsing_errors(date_str):


### PR DESCRIPTION
Fixes #292

## Description of the changes

In nonstrict mode, we allow PDF date strings without the `D:` prefix.


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.
