### PR TITLE
Change ByteRange placeholder to allow bigger input

### DIFF
--- a/pyhanko/sign/signers/pdf_byterange.py
+++ b/pyhanko/sign/signers/pdf_byterange.py
@@ -34,6 +34,9 @@ __all__ = [
 ]
 
 
+BYTE_RANGE_ARR_PLACE_HOLDER_LENGTH = 60
+
+
 class SigByteRangeObject(generic.PdfObject):
     """
     Internal class to handle the ``/ByteRange`` arrays themselves.
@@ -70,13 +73,17 @@ class SigByteRangeObject(generic.PdfObject):
     def write_to_stream(self, stream, handler=None, container_ref=None):
         if self._range_object_offset is None:
             self._range_object_offset = stream.tell()
-        string_repr = "[ %08d %08d %08d %08d ]" % (
-            0,
-            self.first_region_len,
-            self.second_region_offset,
-            self.second_region_len,
-        )
-        stream.write(string_repr.encode('ascii'))
+            stream.write(b"[]")
+            stream.write(b" " * BYTE_RANGE_ARR_PLACE_HOLDER_LENGTH)
+        else:
+            string_repr = b"[%d %d %d %d]" % (
+                0,
+                self.first_region_len,
+                self.second_region_offset,
+                self.second_region_len,
+            )
+            assert len(string_repr) <= BYTE_RANGE_ARR_PLACE_HOLDER_LENGTH + 2
+            stream.write(string_repr)
 
 
 class DERPlaceholder(generic.PdfObject):

--- a/pyhanko_tests/test_signing.py
+++ b/pyhanko_tests/test_signing.py
@@ -154,6 +154,25 @@ def test_simple_sign_fresh_doc():
     val_untrusted(emb)
 
 
+def test_simple_sign_120mb_file():
+    # put this in a function to avoid putting multiple copies
+    #  of a huge buffer in locals
+    def _gen_signed():
+        w = IncrementalPdfFileWriter(BytesIO(MINIMAL))
+        w.root['/YugeObject'] = w.add_object(
+            generic.StreamObject(stream_data=bytes(120 * 1024 * 1024))
+        )
+        w.update_root()
+
+        meta = signers.PdfSignatureMetadata(field_name='Sig1')
+        return signers.sign_pdf(w, meta, signer=SELF_SIGN)
+
+    r = PdfFileReader(_gen_signed())
+    emb = r.embedded_signatures[0]
+    assert emb.field_name == 'Sig1'
+    val_untrusted(emb)
+
+
 def test_append_sigfield_tu_on_signing():
     buf = BytesIO(MINIMAL)
     w = IncrementalPdfFileWriter(buf)


### PR DESCRIPTION

## Description of the changes

This changes the way the `ByteRange` array placeholder is calculated to deal with files larger than 100MB. The root cause was a format string (going back to the very first prototype) that aligned everything to 8 digits. We now always allocate 60 bytes of whitespace and put the offsets in there. This fixes #336.

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

