### PR TITLE
PdfFileReader load cleanup

### DIFF
--- a/pyhanko/pdf_utils/reader.py
+++ b/pyhanko/pdf_utils/reader.py
@@ -14,7 +14,7 @@ import os
 import re
 from collections import defaultdict
 from io import BytesIO
-from typing import Dict, Generator, Optional, Set, Tuple, Union
+from typing import BinaryIO, Dict, Generator, Optional, Set, Tuple, Union
 
 from . import generic, misc
 from .crypt import (
@@ -37,7 +37,6 @@ from .xref import (
 )
 
 logger = logging.getLogger(__name__)
-
 
 __all__ = [
     'PdfFileReader',
@@ -132,6 +131,41 @@ def process_data_at_eof(stream) -> int:
     return startxref
 
 
+def _read_header_version(stream: BinaryIO) -> Tuple[int, int]:
+    stream.seek(0)
+    input_version = None
+    header = misc.read_until_whitespace(stream, maxchars=20)
+    # match ignores trailing chars
+    m = header_regex.match(header)
+    if m is not None:
+        major = int(m.group(1))
+        minor = int(m.group(2))
+        input_version = (major, minor)
+    if input_version is None:
+        raise PdfReadError('Illegal PDF header')
+    return input_version
+
+
+def _read_xrefs_and_trailer(
+    stream: BinaryIO, handler_ref: PdfHandler, strict: bool
+) -> Tuple[XRefCache, XRefBuilder]:
+    # start at the end to read the trailer & xref table
+    stream.seek(-1, os.SEEK_END)
+    # This needs to be recorded for incremental update purposes
+    last_startxref = process_data_at_eof(stream)
+
+    # Read the xref table
+    xref_builder = XRefBuilder(
+        handler=handler_ref,
+        stream=stream,
+        strict=strict,
+        last_startxref=last_startxref,
+    )
+    xref_sections = xref_builder.read_xrefs()
+    xref_cache = XRefCache(handler_ref, xref_sections)
+    return xref_cache, xref_builder
+
+
 class PdfFileReader(PdfHandler):
     """Class implementing functionality to read a PDF file and cache
     certain data about it."""
@@ -151,19 +185,30 @@ class PdfFileReader(PdfHandler):
             problems and also causes some correctable problems to be fatal.
             Defaults to ``True``.
         """
-        self.security_handler: Optional[SecurityHandler] = None
+        self._security_handler: Optional[SecurityHandler] = None
         self.strict = strict
         self.resolved_objects: Dict[Tuple[int, int], generic.PdfObject] = {}
         self._header_version = None
         self._input_version = None
         self._historical_resolver_cache: Dict[int, HistoricalResolver] = {}
         self.stream = stream
-        self.xrefs, self.trailer = self.read()
-        encrypt_dict = self._get_encryption_params()
-        if encrypt_dict is not None:
-            self.security_handler = SecurityHandler.build(encrypt_dict)
+        # first, read the header & PDF version number
+        # (version number can be overridden in the document catalog later)
+        self._header_version = _read_header_version(stream)
+        self.xrefs, xref_builder = _read_xrefs_and_trailer(stream, self, strict)
+        self.last_startxref = xref_builder.last_startxref
+        self.trailer = xref_builder.trailer
+        self.has_xref_stream = xref_builder.has_xref_stream
 
         self._embedded_signatures = None
+
+    @property
+    def security_handler(self):
+        if self._security_handler is None:
+            encrypt_dict = self._get_encryption_params()
+            if encrypt_dict is not None:
+                self._security_handler = SecurityHandler.build(encrypt_dict)
+        return self._security_handler
 
     def _xmp_meta_view(self) -> Optional[DocumentMetadata]:
         try:
@@ -474,40 +519,6 @@ class PdfFileReader(PdfHandler):
     def cache_indirect_object(self, generation, idnum, obj):
         self.resolved_objects[(generation, idnum)] = obj
         return obj
-
-    def read(self):
-        # first, read the header & PDF version number
-        # (version number can be overridden in the document catalog later)
-        stream = self.stream
-        stream.seek(0)
-        input_version = None
-        header = misc.read_until_whitespace(stream, maxchars=20)
-        # match ignores trailing chars
-        m = header_regex.match(header)
-        if m is not None:
-            major = int(m.group(1))
-            minor = int(m.group(2))
-            input_version = (major, minor)
-        if input_version is None:
-            raise PdfReadError('Illegal PDF header')
-        self._header_version = input_version
-
-        # start at the end:
-        stream.seek(-1, os.SEEK_END)
-
-        # This needs to be recorded for incremental update purposes
-        self.last_startxref = last_startxref = process_data_at_eof(stream)
-        # Read the xref table
-        xref_builder = XRefBuilder(
-            handler=self,
-            stream=stream,
-            strict=self.strict,
-            last_startxref=last_startxref,
-        )
-        xref_sections = xref_builder.read_xrefs()
-        xref_cache = XRefCache(self, xref_sections)
-        self.has_xref_stream = xref_builder.has_xref_stream
-        return xref_cache, xref_builder.trailer
 
     def decrypt(self, password: Union[str, bytes]) -> AuthResult:
         """

--- a/pyhanko/pdf_utils/reader.py
+++ b/pyhanko/pdf_utils/reader.py
@@ -344,6 +344,8 @@ class PdfFileReader(PdfHandler):
             raise misc.PdfReadError("Encryption settings must be a dictionary")
         return encrypt_dict
 
+    encrypt_dict = property(_get_encryption_params)
+
     @property
     def trailer_view(self) -> generic.DictionaryObject:
         return self.trailer.flatten()

--- a/pyhanko/pdf_utils/reader.py
+++ b/pyhanko/pdf_utils/reader.py
@@ -331,9 +331,18 @@ class PdfFileReader(PdfHandler):
         except KeyError:
             return None
         if isinstance(encrypt_ref, generic.IndirectObject):
-            return self.get_object(encrypt_ref.reference, never_decrypt=True)
+            encrypt_dict = self.get_object(
+                encrypt_ref.reference, never_decrypt=True
+            )
+        elif not self.strict:
+            encrypt_dict = encrypt_ref
         else:
-            return encrypt_ref
+            raise misc.PdfReadError(
+                "Encryption settings must be an indirect reference"
+            )
+        if not isinstance(encrypt_dict, generic.DictionaryObject):
+            raise misc.PdfReadError("Encryption settings must be a dictionary")
+        return encrypt_dict
 
     @property
     def trailer_view(self) -> generic.DictionaryObject:

--- a/pyhanko/pdf_utils/xref.py
+++ b/pyhanko/pdf_utils/xref.py
@@ -642,7 +642,7 @@ class XRefBuilder:
         self.sections: List[XRefSection] = []
 
         self.trailer = TrailerDictionary()
-        self.trailer.container_ref = generic.TrailerReference(self)
+        self.trailer.container_ref = generic.TrailerReference(handler)
         self.has_xref_stream = False
 
     def _read_xref_stream_object(self):

--- a/pyhanko_tests/data/pdf/malformed-encrypt-dict1.pdf
+++ b/pyhanko_tests/data/pdf/malformed-encrypt-dict1.pdf
@@ -1,0 +1,31 @@
+%PDF-1.7
+%¿÷¢ş
+1 0 obj
+<< /Pages 2 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Count 1 /Kids [ 3 0 R ] /MediaBox [ 0 0 300 144 ] /Type /Pages >>
+endobj
+3 0 obj
+<< /Contents 4 0 R /Parent 2 0 R /Resources << /Font << /F1 << /BaseFont /Times-Roman /Subtype /Type1 /Type /Font >> >> >> /Type /Page >>
+endobj
+4 0 obj
+<< /Length 52 /Filter /FlateDecode >>
+stream
+–W.áN0ğ¦\,ÅDÊ×şT=³!›cÃ†µ}MaúsÔ9r*UÈñÍßs«äîV‚µendstream
+endobj
+5 0 obj
+<< /Filter /Standard /Length 128 /O <5058e693ce1983769c0b66c060b2dec09b0c252f524622a0c654b731d2b1e59b> /P -4 /R 3 /U <bafa4880001a1d23e5317fc6894d05ae0122456a91bae5134273a6db134c87c4> /V 2 >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000149 00000 n 
+0000000302 00000 n 
+0000000424 00000 n 
+trailer << /Root 1 0 R /Size 6 /ID [<a106c88ef69483d1156ac347e5850fbc><a106c88ef69483d1156ac347e5850fbc>] /Encrypt << /Filter /Standard /Length 128 /O <5058e693ce1983769c0b66c060b2dec09b0c252f524622a0c654b731d2b1e59b> /P -4 /R 3 /U <bafa4880001a1d23e5317fc6894d05ae0122456a91bae5134273a6db134c87c4> /V 2 >> >>
+startxref
+631
+%%EOF

--- a/pyhanko_tests/data/pdf/malformed-encrypt-dict2.pdf
+++ b/pyhanko_tests/data/pdf/malformed-encrypt-dict2.pdf
@@ -1,0 +1,31 @@
+%PDF-1.7
+%¿÷¢ş
+1 0 obj
+<< /Pages 2 0 R /Type /Catalog >>
+endobj
+2 0 obj
+<< /Count 1 /Kids [ 3 0 R ] /MediaBox [ 0 0 300 144 ] /Type /Pages >>
+endobj
+3 0 obj
+<< /Contents 4 0 R /Parent 2 0 R /Resources << /Font << /F1 << /BaseFont /Times-Roman /Subtype /Type1 /Type /Font >> >> >> /Type /Page >>
+endobj
+4 0 obj
+<< /Length 52 /Filter /FlateDecode >>
+stream
+–W.áN0ğ¦\,ÅDÊ×şT=³!›cÃ†µ}MaúsÔ9r*UÈñÍßs«äîV‚µendstream
+endobj
+5 0 obj
+<< /Filter /Standard /Length 128 /O <5058e693ce1983769c0b66c060b2dec09b0c252f524622a0c654b731d2b1e59b> /P -4 /R 3 /U <bafa4880001a1d23e5317fc6894d05ae0122456a91bae5134273a6db134c87c4> /V 2 >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000149 00000 n 
+0000000302 00000 n 
+0000000424 00000 n 
+trailer << /Root 1 0 R /Size 6 /ID [<a106c88ef69483d1156ac347e5850fbc><a106c88ef69483d1156ac347e5850fbc>] /Encrypt []    >>
+startxref
+631
+%%EOF

--- a/pyhanko_tests/test_crypt.py
+++ b/pyhanko_tests/test_crypt.py
@@ -493,7 +493,8 @@ def test_pubkey_unsupported_filter(delete_subfilter):
     out = BytesIO()
     w.write(out)
     with pytest.raises(misc.PdfReadError):
-        PdfFileReader(out)
+        # noinspection PyStatementEffect
+        PdfFileReader(out).root['/Pages']['/Kids'][0]['/Content'].data
 
 
 def test_pubkey_encryption_block_cfs_s4():
@@ -505,7 +506,8 @@ def test_pubkey_encryption_block_cfs_s4():
     out = BytesIO()
     w.write(out)
     with pytest.raises(misc.PdfReadError):
-        PdfFileReader(out)
+        # noinspection PyStatementEffect
+        PdfFileReader(out).root['/Pages']['/Kids'][0]['/Content'].data
 
 
 def test_pubkey_encryption_s5_requires_cfs():
@@ -518,7 +520,8 @@ def test_pubkey_encryption_s5_requires_cfs():
     out = BytesIO()
     w.write(out)
     with pytest.raises(misc.PdfReadError):
-        PdfFileReader(out)
+        # noinspection PyStatementEffect
+        PdfFileReader(out).root['/Pages']['/Kids'][0]['/Content'].data
 
 
 def test_pubkey_encryption_dict_errors():
@@ -1433,7 +1436,8 @@ def test_legacy_o_u_values(entry):
     w.write(out)
 
     with pytest.raises(misc.PdfError, match="be 32 bytes long"):
-        PdfFileReader(out)
+        # noinspection PyStatementEffect
+        PdfFileReader(out).root['/Pages']['/Kids'][0]['/Content'].data
 
 
 def test_key_length_constraint():


### PR DESCRIPTION
## Description of the changes

Clean up some of the init logic in `PdfFileReader` (without fundamentally changing the fact that the xref table is processed during `__init__`), and in particular, for encrypted files, we now defer loading of the security handler to a later point. As a side effect, this means that problems with the security handler will be raised during object access and/or calls to `.encrypt()/.decrypt()` rather than during `__init__`, which is hopefully a bit more user-friendly. It also exposes the encryption dictionary as a property on the `PdfFileReader` class.
Closes #332. 


## Caveats

Technically, the removal of the `.read()` method on `PdfFileReader` is a breaking change. Practically, it's not, since calling that method out of order would already have broken all sorts of things anyway.

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.

