### PR TITLE
Remove repeated line and improve naming consistency

### DIFF
--- a/docs/lib-guide/signing.rst
+++ b/docs/lib-guide/signing.rst
@@ -817,7 +817,7 @@ remote signers that supply complete CMS objects.
             ),
             timestamper=timestamps.HTTPTimeStamper('http://tsa.example.com')
         )
-        prep_digest, tbs_document, output = \
+        prep_digest, tbs_document, output_handle = \
             await pdf_signer.async_digest_doc_for_signing(w)
         md_algorithm = tbs_document.md_algorithm
         psi = tbs_document.post_sign_instructions
@@ -825,8 +825,7 @@ remote signers that supply complete CMS objects.
         signed_attrs = await ext_signer.signed_attrs(
             prep_digest.document_digest, 'sha256', use_pades=True
         )
-        psi = tbs_document.post_sign_instructions
-        return prep_digest, signed_attrs, psi, output
+        return prep_digest, signed_attrs, psi, output_handle
 
     # After prep_document finishes, you can serialise the contents
     # of prep_digest, signed_attrs and psi somewhere.


### PR DESCRIPTION
* The line `psi = tbs_document.post_sign_instructions` needlessly appeared twice in the code.

* The first part's `output` variable is used as `output_handle` in the second part. Make both names consistent.

## Description of the changes

Small documentation fix in the interrupted signing example code.

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.

### For documentation contributions (delete if not applicable)

 - [x] I have built the HTML documentation locally, and verified that the changes behave correctly in-browser.
