### PR TITLE
Relax requirements around PKCS#11 config

### DIFF
--- a/pyhanko/config/pkcs11.py
+++ b/pyhanko/config/pkcs11.py
@@ -224,24 +224,32 @@ class PKCS11SignatureConfig(api.ConfigurableMixin):
             config_dict['key_id'] = _process_pkcs11_id_value(
                 config_dict['key_id']
             )
-        elif 'key_label' not in config_dict and 'cert_label' not in config_dict:
-            raise ConfigurationError(
-                "Either 'key_id', 'key_label' or 'cert_label' must be provided "
-                "in PKCS#11 setup"
-            )
 
         if 'cert_id' in config_dict:
             config_dict['cert_id'] = _process_pkcs11_id_value(
                 config_dict['cert_id']
             )
-        elif (
+
+        if 'key_label' not in config_dict and 'key_id' not in config_dict:
+            if 'cert_id' not in config_dict and 'cert_label' not in config_dict:
+                raise ConfigurationError(
+                    "Either 'key_id', 'key_label', 'cert_label' or 'cert_id',"
+                    "must be provided in PKCS#11 setup"
+                )
+            if 'cert_id' in config_dict:
+                config_dict['key_id'] = config_dict['cert_id']
+            if 'cert_label' in config_dict:
+                config_dict['key_label'] = config_dict['cert_label']
+
+        if (
             'cert_label' not in config_dict
+            and 'cert_id' not in config_dict
             and 'signing_certificate' not in config_dict
         ):
-            raise ConfigurationError(
-                "Either 'cert_id', 'cert_label' or 'signing_certificate' "
-                "must be provided in PKCS#11 setup"
-            )
+            if 'key_id' in config_dict:
+                config_dict['cert_id'] = config_dict['key_id']
+            if 'key_label' in config_dict:
+                config_dict['cert_label'] = config_dict['key_label']
 
         config_dict['prompt_pin'] = get_and_apply(
             config_dict,

--- a/pyhanko/pdf_utils/misc.py
+++ b/pyhanko/pdf_utils/misc.py
@@ -555,3 +555,10 @@ class _LiftedIterable(CancelableAsyncIterator[X]):
 
 def lift_iterable_async(i: Iterable[X]) -> CancelableAsyncIterator[X]:
     return _LiftedIterable(i)
+
+
+def coalesce(*args):
+    for arg in args:
+        if arg is not None:
+            return arg
+    return None

--- a/pyhanko/sign/pkcs11.py
+++ b/pyhanko/sign/pkcs11.py
@@ -23,6 +23,7 @@ from pyhanko.config.pkcs11 import (
     PKCS11SignatureConfig,
     TokenCriteria,
 )
+from pyhanko.pdf_utils.misc import coalesce
 from pyhanko.sign.general import SigningError, get_pyca_cryptography_hash
 from pyhanko.sign.signers import Signer
 
@@ -516,23 +517,10 @@ class PKCS11Signer(Signer):
         """
         Initialise a PKCS11 signer.
         """
-        if signing_cert is None and cert_id is None and cert_label is None:
-            raise SigningError(
-                "Please specify a signer's certificate through the "
-                "'cert_id', 'signing_cert' and/or 'cert_label' options"
-            )
-
-        self.cert_label = cert_label
-        self.key_id = key_id
-        self.cert_id = cert_id
-        if key_id is None and key_label is None:
-            if cert_label is None:
-                raise SigningError(
-                    "If 'cert_label' is None, then 'key_label' or 'key_id' "
-                    "must be provided."
-                )
-            key_label = cert_label
-        self.key_label = key_label
+        self.cert_label = coalesce(cert_label, key_label)
+        self.key_id = coalesce(key_id, cert_id)
+        self.cert_id = coalesce(cert_id, key_id)
+        self.key_label = coalesce(key_label, cert_label)
         self.pkcs11_session = pkcs11_session
         self.other_certs = other_certs_to_pull
         self._other_certs_loaded = False


### PR DESCRIPTION
## Description of the changes

 - Allow key label / id to be defaulted from the corresponding cert settings and vice-versa. Most PKCS#11 token layouts follow a reasonable naming scheme where for a given key <> cert pair, either the IDs or the labels coincide, so this allows for better ergonomics there.
 - For directly instantiated `PKCS11Signer` s, delay throwing errors until key/cert lookup (allows even more flexibility at the cost of slightly less informative error messages at this level of the API)

Fixes #386

## Caveats

There is a minor change in exception behaviour inside `PKCS11Signer`, since the `__init__` method no longer does any validation.

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [x] All public API functionality in this PR is documented.