### PR TITLE
Fix regression in looking up PKCS#11 objects

### DIFF
--- a/pyhanko/sign/pkcs11.py
+++ b/pyhanko/sign/pkcs11.py
@@ -47,7 +47,6 @@ except ImportError as e:  # pragma: nocover
         e,
     )
 
-
 __all__ = [
     'PKCS11Signer',
     'open_pkcs11_session',
@@ -165,7 +164,6 @@ RSA_MECH_MAP = {
     'sha512': Mechanism.SHA512_RSA_PKCS,
 }
 
-
 RSASSA_PSS_MECH_MAP = {
     'sha1': Mechanism.SHA1_RSA_PKCS_PSS,
     'sha224': Mechanism.SHA224_RSA_PKCS_PSS,
@@ -182,7 +180,6 @@ MGF_MECH_MAP = {
     'sha512': MGF.SHA512,
 }
 
-
 ECDSA_MECH_MAP = {
     'sha1': Mechanism.ECDSA_SHA1,
     'sha224': Mechanism.ECDSA_SHA224,
@@ -190,7 +187,6 @@ ECDSA_MECH_MAP = {
     'sha384': Mechanism.ECDSA_SHA384,
     'sha512': Mechanism.ECDSA_SHA512,
 }
-
 
 DSA_MECH_MAP = {
     'sha1': Mechanism.DSA_SHA1,
@@ -203,7 +199,6 @@ DSA_MECH_MAP = {
     'sha384': Mechanism.DSA_SHA384,
     'sha512': Mechanism.DSA_SHA512,
 }
-
 
 DIGEST_MECH_MAP = {
     'sha1': Mechanism.SHA_1,
@@ -517,10 +512,12 @@ class PKCS11Signer(Signer):
         """
         Initialise a PKCS11 signer.
         """
-        self.cert_label = coalesce(cert_label, key_label)
-        self.key_id = coalesce(key_id, cert_id)
-        self.cert_id = coalesce(cert_id, key_id)
-        self.key_label = coalesce(key_label, cert_label)
+        self.cert_label = coalesce(
+            cert_label, key_label if not cert_id else None
+        )
+        self.key_id = coalesce(key_id, cert_id if not key_label else None)
+        self.cert_id = coalesce(cert_id, key_id if not cert_label else None)
+        self.key_label = coalesce(key_label, cert_label if not key_id else None)
         self.pkcs11_session = pkcs11_session
         self.other_certs = other_certs_to_pull
         self._other_certs_loaded = False

--- a/pyhanko_tests/test_config.py
+++ b/pyhanko_tests/test_config.py
@@ -820,6 +820,22 @@ def test_read_pkcs11_config_key_label_from_cert_label():
     assert (cfg.key_label, cfg.key_id) == ("signer", None)
 
 
+def test_read_pkcs11_config_key_label_not_from_cert_label_if_key_id_defined():
+    cli_config = _parse_cli_config(
+        f"""
+        pkcs11-setups:
+            foo:
+                module-path: /path/to/libfoo.so
+                slot-no: 0
+                cert-label: "signer"
+                key-id: "deadbeef"
+        """
+    )
+    cfg = ModuleConfigWrapper(cli_config).get_pkcs11_config('foo')
+    assert (cfg.key_label, cfg.key_id) == (None, b"\xde\xad\xbe\xef")
+    assert (cfg.cert_label, cfg.cert_id) == ("signer", None)
+
+
 @pytest.mark.parametrize(
     'literal,exp_val',
     [


### PR DESCRIPTION
## Description of the changes

Some config fallbacks in the PKCS#11 setup were a little too aggressive, leading to overly specific lookups in some cases.

Fixes #394.

## Caveats

None

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.
