### PR TITLE
Tolerate AcroForms without a Fields entry

### DIFF
--- a/pyhanko/sign/fields.py
+++ b/pyhanko/sign/fields.py
@@ -1473,7 +1473,7 @@ def prepare_sig_field(
         try:
             fields = form['/Fields']
         except KeyError:
-            raise PdfError('/AcroForm has no /Fields')
+            fields = form['/Fields'] = generic.ArrayObject()
 
         candidates = enumerate_sig_fields_in(
             fields, with_name=sig_field_name, refs_seen=set()

--- a/pyhanko_tests/test_fields.py
+++ b/pyhanko_tests/test_fields.py
@@ -439,8 +439,6 @@ def test_append_sig_field_acro_update():
 
 def test_append_acroform_no_fields():
     w = PdfFileWriter()
-    # Technically, this is not standards-compliant, but our routine
-    # shouldn't care
     w.root['/AcroForm'] = generic.DictionaryObject()
     w.insert_page(simple_page(w, 'Hello world'))
     out = BytesIO()
@@ -449,8 +447,11 @@ def test_append_acroform_no_fields():
 
     sp = fields.SigFieldSpec('InvisibleSig')
     w = IncrementalPdfFileWriter(out)
-    with pytest.raises(PdfError, match="has no /Fields"):
-        fields.append_signature_field(w, sp)
+    fields.append_signature_field(w, sp)
+    w.write_in_place()
+
+    r = PdfFileReader(out)
+    assert len(r.root['/AcroForm']['/Fields']) == 1
 
 
 def test_append_acroform_reference_broken_nonstrict():


### PR DESCRIPTION
## Description of the changes


Tolerate **AcroForm** dictionaries that don't contain a **Fields** entry when making changes to a PDF. We'll create it on the fly if needed, even though the input document would strictly speaking not be valid.

Fixes #403.


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.
