### PR TITLE
CLI: Parse --force flag

### DIFF
--- a/pyhanko/cli/commands/crypt.py
+++ b/pyhanko/cli/commands/crypt.py
@@ -70,7 +70,6 @@ decrypt_force_flag = click.option(
     '--force',
     help='ignore access restrictions (use at your own risk)',
     required=False,
-    type=bool,
     is_flag=True,
     default=False,
 )


### PR DESCRIPTION
## Description of the changes

The `decrypt_force_flag = click.option()`  - at least for me - cannot be set to `True` right now. As far as I can tell, this is caused by the fact that the option is explicitly set (`type=bool`) as well as implicitly (`is_flag=True`).

Removing the explicit declaration resolves the issue.

## Caveats

None known

## Checklist

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.

### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [ ] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

## Additional comments

I didn't invest too much time into the tests - but from a quick look, `pytest pyhanko_tests/cli_tests/test_cli_crypt.py` is now not failing `test_decrypt_with_private_key_force_change_of_encryption_forbidden` and ` test_decrypt_with_private_key_force_change_of_encryption_forbidden` anymore...