### PR TITLE
Add missing @with_layout_comparison decorator to two tests

### DIFF
--- a/pkgs/pyhanko/tests/test_stamp.py
+++ b/pkgs/pyhanko/tests/test_stamp.py
@@ -437,6 +437,7 @@ def test_zero_width_error():
     stamp.apply(0, x=10, y=500)
 
 
+@with_layout_comparison
 def test_simple_text_stamp_on_page_with_leaky_graphics_state():
     with open(f"{PDF_DATA_DIR}/leaky-graphics-state-doc.pdf", 'rb') as fin:
         pdf_out = IncrementalPdfFileWriter(fin, strict=False)
@@ -450,6 +451,7 @@ def test_simple_text_stamp_on_page_with_leaky_graphics_state():
         )
 
 
+@with_layout_comparison
 def test_simple_text_stamp_on_page_with_leaky_graphics_state_without_coord_correction():
     with open(f"{PDF_DATA_DIR}/leaky-graphics-state-doc.pdf", 'rb') as fin:
         pdf_out = IncrementalPdfFileWriter(fin, strict=False)


### PR DESCRIPTION
## Description of the changes
These tests both run `compare_outputs` at the end, which leads those tests to fail under circumstances which prevent comparing layouts. (No `pdftoppm` or `compare`).

Describe the changes in this PR, with references to issues in the issue tracker and forum discussions (if applicable).


## Caveats

If the implementation has "sharp edges" or is otherwise incomplete, please explain here. Deviations from the contribution guidelines should also be motivated in this section.

In particular, if your contribution includes any of the following, please provide a brief justification here:

 - Changes to project dependencies.
 - Changes to existing public APIs (particularly if they could break existing user code) or the CLI.
 - Nontrivial changes to internal (non-public) APIs


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [ ] All new code in this PR has full test coverage. (Not applicable)


## Additional comments

Feel free to add any additional comments here.
