### PR TITLE
Add 'PreserveStampStyle' stamp style which preserves existing appearance.

### DIFF
--- a/pkgs/pyhanko/src/pyhanko/sign/signers/cms_embedder.py
+++ b/pkgs/pyhanko/src/pyhanko/sign/signers/cms_embedder.py
@@ -262,7 +262,8 @@ class SigAppearanceSetup:
             stamp = self._appearance_stamp(
                 writer, BoxConstraints(width=w, height=h)
             )
-            stamp.apply_appearance(sig_annot)
+            if stamp:
+                stamp.apply_appearance(sig_annot)
 
     def _appearance_stamp(self, writer, box):
         style = self.style

--- a/pkgs/pyhanko/src/pyhanko/stamp/__init__.py
+++ b/pkgs/pyhanko/src/pyhanko/stamp/__init__.py
@@ -13,6 +13,7 @@ from .appearances import CoordinateSystem
 from .art import STAMP_ART_CONTENT
 from .base import BaseStamp, BaseStampStyle
 from .functions import qr_stamp_file, text_stamp_file
+from .noop import NoOpStampStyle
 from .qr import QRPosition, QRStamp, QRStampStyle
 from .static import StaticContentStamp, StaticStampStyle
 from .text import TextStamp, TextStampStyle
@@ -30,6 +31,7 @@ __all__ = [
     "StaticStampStyle",
     "TextStamp",
     "TextStampStyle",
+    "NoOpStampStyle",
     "qr_stamp_file",
     "text_stamp_file",
 ]

--- a/pkgs/pyhanko/src/pyhanko/stamp/base.py
+++ b/pkgs/pyhanko/src/pyhanko/stamp/base.py
@@ -103,7 +103,7 @@ class BaseStampStyle(ConfigurableMixin):
         writer: BasePdfFileWriter,
         box: layout.BoxConstraints,
         text_params: dict,
-    ) -> 'BaseStamp':
+    ) -> Optional['BaseStamp']:
         raise NotImplementedError
 
 

--- a/pkgs/pyhanko/src/pyhanko/stamp/noop.py
+++ b/pkgs/pyhanko/src/pyhanko/stamp/noop.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+from pyhanko.pdf_utils import layout
+from pyhanko.pdf_utils.writer import BasePdfFileWriter
+
+from .base import BaseStampStyle
+
+__all__ = ['NoOpStampStyle']
+
+
+@dataclass(frozen=True)
+class NoOpStampStyle(BaseStampStyle):
+    """
+    Stamp style that generates no stamp (preserves existing signature appearance)
+    """
+
+    def create_stamp(
+        self,
+        writer: BasePdfFileWriter,
+        box: layout.BoxConstraints,
+        text_params: dict,
+    ) -> None:
+        return None


### PR DESCRIPTION
## Description of the changes

Regarding issue 610:

https://github.com/MatthiasValvekens/pyHanko/issues/610

This is a very basic implementation to add this feature without API modifications.

1) cms_embedder.py: Only apply a stamp if the style returns a stamp.
2) Add PreserveStampStyle stamp style which just returns None for a stamp.


## Caveats

There is no error checking.  If this style is applied to a signature without an existing appearance, then the final signature will have no appearance without any errors or warnings.

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x ] I have read the project's CoC and contribution guidelines.
 - [x ] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [ ] All new code in this PR has full test coverage.


### For new features (delete if not applicable)

 - [x ] I have discussed the implementation of this feature with the project maintainer(s) on the discussion forum or over email.
 - [x ] I have verified that my changes do not break existing API or CLI functionality, or ensured that all breaking changes are clearly documented in this PR.
 - [ ] All public API functionality in this PR is documented.

## Additional comments

This is based on my initial proposal, but I am not 100% sure this is what you had in mind.
