### PR TITLE
Use embedded intermediate certificates when validating existing timestamps

### DIFF
--- a/pkgs/pyhanko/src/pyhanko/sign/signers/pdf_signer.py
+++ b/pkgs/pyhanko/src/pyhanko/sign/signers/pdf_signer.py
@@ -4,6 +4,7 @@ This module implements support for PDF-specific signing functionality.
 
 import asyncio
 import enum
+import itertools
 import logging
 import uuid
 import warnings
@@ -1894,7 +1895,9 @@ class PdfSigningSession:
         if last_ts is not None:
             ts_validator = CertificateValidator(
                 last_ts.signer_cert,
-                intermediate_certs=signer.cert_registry,
+                intermediate_certs=itertools.chain(
+                    signer.cert_registry, last_ts.other_embedded_certs
+                ),
                 validation_context=validation_context,
             )
             try:


### PR DESCRIPTION
## Description of the changes

Issue:
https://github.com/MatthiasValvekens/pyHanko/issues/611

This change attempts to have minimum possible impact, while adding embedded certificates from a timestamp, when validating that timestamp.

Itertools is a system library, so there are no extra dependencies introduced.


## Caveats

None

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [ ] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [ ] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [ ] All new code in this PR has full test coverage.


## Additional comments

By chaining signer.cert_registry, existing functionality should be fully preserved, while still allowing the signature object to provide intermediate certs for validation.
