### PR TITLE
Add content-type for swissign.net crls

### DIFF
--- a/pkgs/pyhanko-certvalidator/src/pyhanko_certvalidator/fetchers/common_utils.py
+++ b/pkgs/pyhanko-certvalidator/src/pyhanko_certvalidator/fetchers/common_utils.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 ACCEPTABLE_STRICT_CERT_CONTENT_TYPES = frozenset(
     [
         'application/pkix-cert',
+        'application/pkix-ca',
         'application/pkcs7-mime',
         'application/x-x509-ca-cert',
         'application/x-pkcs7-certificates',


### PR DESCRIPTION
## Description of the changes

Issue:
https://github.com/MatthiasValvekens/pyHanko/issues/613

Add the Content-Type 'application/pkix-ca' to ACCEPTABLE_STRICT_CERT_CONTENT_TYPES so that the CRLs from swissign.net can be used.

## Caveats

None

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [ ] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [ ] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [ ] All new code in this PR has full test coverage.


## Additional comments

I do not like adding non-standard mime-types here.  But at least for our application, it is required that we can validate CRLs from swissign.net.
