### PR TITLE
fix: FieldMDP incorrectly locking fields with shared name prefix

### DIFF
--- a/pkgs/pyhanko/src/pyhanko/sign/fields.py
+++ b/pkgs/pyhanko/src/pyhanko/sign/fields.py
@@ -1194,8 +1194,12 @@ class FieldMDPSpec:
         for scoped_field_name in self.fields or ():
             # treat non-terminal field in/exclusions as including the whole
             # tree beneath them
-            if field_name.startswith(scoped_field_name):
+            if (
+                field_name.startswith(scoped_field_name + ".")
+                or field_name == scoped_field_name
+            ):
                 return lock_result
+
         return not lock_result
 
 

--- a/pkgs/pyhanko/tests/test_diff_analysis.py
+++ b/pkgs/pyhanko/tests/test_diff_analysis.py
@@ -2723,3 +2723,33 @@ def test_signature_without_type_is_form_filling():
         assert (
             s.diff_result.modification_level == ModificationLevel.FORM_FILLING
         )
+
+
+@freeze_time('2020-11-01')
+def test_fieldmdp_include_does_not_lock_field_with_shared_name_prefix():
+    # Ensure a FieldMDP lock on "Signature1" does not incorrectly flag "Signature10" as locked due to "Signature1" being a prefix of "Signature10"
+    w = IncrementalPdfFileWriter(BytesIO(MINIMAL))
+    out = signers.sign_pdf(
+        w,
+        signers.PdfSignatureMetadata(field_name="Signature1"),
+        new_field_spec=fields.SigFieldSpec(
+            sig_field_name="Signature1",
+            field_mdp_spec=fields.FieldMDPSpec(
+                fields.FieldMDPAction.INCLUDE, ["Signature1"]
+            ),
+        ),
+        signer=FROM_CA,
+    )
+
+    w = IncrementalPdfFileWriter(out)
+    out = signers.sign_pdf(
+        w,
+        signers.PdfSignatureMetadata(field_name="Signature10"),
+        signer=FROM_CA,
+    )
+
+    r = PdfFileReader(out)
+    for sig in r.embedded_signatures:
+        status = validate_pdf_signature(sig, simple_v_context())
+        assert status.docmdp_ok
+        assert status.bottom_line


### PR DESCRIPTION
## Description of the changes

Fixes bug report at https://github.com/MatthiasValvekens/pyHanko/issues/633.

`FieldMDP.is_locked` was using a string prefix check to determine if a field is covered by `/Fields`, causing fields like `Signature10` to be incorrectly flagged as locked when `Signature1` was listed. The fix requires matches to end on a complete partial name: either an exact match or followed by a `.` separator.


## Caveats

-


## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.


### For bug fixes (delete if not applicable)

 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.