### PR TITLE
Use Europe/Brussels, not CET in zoneinfo.ZoneInfo

### DIFF
--- a/pkgs/pyhanko/src/pyhanko/sign/validation/qualified/assess.py
+++ b/pkgs/pyhanko/src/pyhanko/sign/validation/qualified/assess.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 EIDAS_START_DATE = datetime(
-    2016, 7, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo('CET')
+    2016, 7, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo('Europe/Brussels')
 )
 
 PRE_EIDAS_QCP_POLICY = '0.4.0.1456.1.1'
@@ -203,7 +203,9 @@ class QualificationAssessor:
             )
         prelim_status = QualificationAssessor._process_qc_statements(cert)
         path_policies = path.qualified_policies()
-        reference_time = moment or datetime.now(tz=zoneinfo.ZoneInfo('CET'))
+        reference_time = moment or datetime.now(
+            tz=zoneinfo.ZoneInfo('Europe/Brussels')
+        )
         if reference_time < EIDAS_START_DATE and path_policies:
             # check QCP / QCP+ policy
             policy_oids = {q.user_domain_policy_id for q in path_policies}

--- a/pkgs/pyhanko/tests/test_meta.py
+++ b/pkgs/pyhanko/tests/test_meta.py
@@ -83,7 +83,7 @@ def test_incremental_update_meta_view():
 @pytest.mark.parametrize('writer_type', ('fresh', 'from_data', 'incremental'))
 def test_writer_meta_view_does_not_persist_changes(writer_type):
     exp_value = datetime(
-        2020, 9, 5, 19, 30, 57, tzinfo=zoneinfo.ZoneInfo('CET')
+        2020, 9, 5, 19, 30, 57, tzinfo=zoneinfo.ZoneInfo('Europe/Brussels')
     )
     if writer_type == 'fresh':
         w = PdfFileWriter()


### PR DESCRIPTION
## Description of the changes

The canonical name in the zone database is Europe/Brussels (or another neighboring city). Timezone abbreviations are ambiguous, not part of the tzdata database and not present in all systems. Debian/Ubuntu systems, for example, do not ship a CET zone.

## Caveats

None

## Checklist

Please go over this checklist to increase the chances of your PR being worked on in a timely manner. Deviations are allowed with proper justification (see previous section).

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] All new code in this PR has full test coverage.

### For bug fixes

 - [x] My changes do not affect any public API or CLI semantics.
 - [ ] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.