### PR TITLE
Fix ISO 32000-1 §7.4.2 odd-digit handling in ASCIIHexDecode

### DIFF
--- a/pkgs/pyhanko/src/pyhanko/pdf_utils/filters.py
+++ b/pkgs/pyhanko/src/pyhanko/pdf_utils/filters.py
@@ -149,6 +149,10 @@ class ASCIIHexDecode(Decoder, metaclass=Singleton):
     def decode(self, data, decode_params=None):
         data, _ = data.split(ASCII_HEX_EOD_MARKER, 1)
         data = WS_REGEX.sub(b'', data)
+        # Per ISO 32000-2 §7.4.2: an odd number of hexadecimal digits
+        # before the EOD marker is treated as if a trailing 0 were present.
+        if len(data) % 2:
+            data += b'0'
         return binascii.unhexlify(data)
 
 

--- a/pkgs/pyhanko/tests/test_internal_utils.py
+++ b/pkgs/pyhanko/tests/test_internal_utils.py
@@ -337,6 +337,20 @@ def test_ascii_hex_decode():
     assert filters.ASCIIHexDecode().decode(encoded) == data
 
 
+def test_ascii_hex_decode_odd_digits():
+    # Per ISO 32000-2 §7.4.2: an odd number of hexadecimal digits before
+    # the EOD marker shall be handled as if a trailing 0 were present.
+    from pyhanko.pdf_utils import filters
+
+    decoder = filters.ASCIIHexDecode()
+    # '6C6C6' is odd-length; spec mandates it be treated as '6C6C60'.
+    assert decoder.decode(b'6C6C6>') == b'll\x60'
+    # Whitespace inside the stream is ignored before the parity check.
+    assert decoder.decode(b'6C 6C\n6>') == b'll\x60'
+    # A single trailing nibble decodes to a single zero-padded byte.
+    assert decoder.decode(b'A>') == b'\xa0'
+
+
 def test_ascii85_decode():
     from pyhanko.pdf_utils import filters
 


### PR DESCRIPTION
## Description of the bug

`ASCIIHexDecode.decode` in `pkgs/pyhanko/src/pyhanko/pdf_utils/filters.py` violates ISO 32000-1 §7.4.2:

> If the filter encounters the EOD marker after reading an odd number of hexadecimal digits, it shall behave as if a 0 (zero) followed the last digit.

The decoder passes the digit string straight to `binascii.unhexlify`, so a stream with an odd number of hex digits before `>` raises `binascii.Error: Odd-length string` instead of decoding as the spec requires. The exception type also escapes the `StreamObject.data` contract, which is documented to raise `PdfStreamError`.

The path is reachable end-to-end from `PdfFileReader` whenever a parsed stream uses `/Filter /AHx` (or `/ASCIIHexDecode`).

### Reproduction (before this PR)

```python
from pyhanko.pdf_utils.generic import StreamObject, NameObject
stream = StreamObject(
    dict_data={NameObject('/Filter'): NameObject('/AHx')},
    encoded_data=b'6C6C6>',  # 5 hex digits before EOD => odd
)
stream.data
# binascii.Error: Odd-length string
```

Expected per spec: `b'll\x60'` — i.e. `6C6C6>` is treated as `6C6C60>`.

### Fix

When the post-whitespace digit string has odd length, append a single `'0'` nibble before calling `binascii.unhexlify`. Spec quote retained inline.

## Caveats

None. The change is one-line, fully localised to `ASCIIHexDecode.decode`, and only changes behaviour on input that previously raised an exception (no impact on streams that decoded successfully before).

## Checklist

 - [x] I have read the project's CoC and contribution guidelines.
 - [x] I understand and agree to the terms in the [Developer Certificate of Origin](https://developercertificate.org/) as applied to this contribution.
 - [x] My changes do not affect any public API or CLI semantics.
 - [x] My PR adds regression tests (i.e. tests that fail if the bug fix is _not_ applied).
 - [x] All new code in this PR has full test coverage.

## Additional comments

The new `test_ascii_hex_decode_odd_digits` covers three cases:

1. Plain odd-length input (`6C6C6>` → `b'll\x60'`).
2. Whitespace-mixed odd-length input (`6C 6C\n6>` → `b'll\x60'`), exercising the order-of-operations between whitespace stripping and the parity check.
3. A single trailing nibble (`A>` → `b'\xa0'`).

Existing `test_ascii_hex_decode` round-trip and `test_ascii85_decode` continue to pass; running the full `test_internal_utils.py` shows the same pass/fail counts as `master` apart from the new regression test, which passes.